### PR TITLE
[Feat/implement-request-handler] : Implement Handling TCP Socket Connections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## 🐣Title
+
+---
+
+<br/>
+
+## 🐣Part
+
+---
+
+<br/>
+
+## 🐣Key Changes
+
+---
+
+<br/>
+
+## 🐣Simulation
+
+---
+
+<br/>
+
+## 🐣To Reviewer
+
+---
+
+<br/>
+
+## 🐣Next
+
+---
+
+ <br/>
+
+## 🐣Issue
+
+---
+
+
+<br/>

--- a/server/src/main/java/org/kunp/Main.java
+++ b/server/src/main/java/org/kunp/Main.java
@@ -1,7 +1,97 @@
 package org.kunp;
 
+import static org.kunp.ServerConstant.*;
+
+import java.net.ServerSocket;
+import java.util.Map;
+import java.util.Optional;
+import org.kunp.Servlet.*;
+import org.kunp.Servlet.session.*;
+
 public class Main {
+
+  public static final ThreadGroup threadGroup = new ThreadGroup("ActiveThreads");
+  private static ServerSocket serverSocket;
+  private static SessionStorage sessionStorage;
+  private static ISessionIdGenerator sessionIdGenerator;
+  private static SessionManager sessionManager;
+  private static ConnectionConfigurer connectionConfigurer;
+
   public static void main(String[] args) {
-    System.out.println("Hello world!");
+    initDependencies();
+    Thread reactorThread =
+        startReactor().orElseThrow(() -> new RuntimeException("Failed to start reactor thread"));
+    startMonitorThread();
+
+    try {
+      killAllActiveThreads();
+      reactorThread.join();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } finally {
+      closeServerSocket();
+    }
+  }
+
+  private static void initDependencies() {
+    try {
+      serverSocket = new ServerSocket(SERVER_PORT);
+      sessionStorage = new SessionInMemoryStorage();
+      sessionIdGenerator = new SessionIdGenerator();
+      sessionManager = new SessionManager(sessionStorage, sessionIdGenerator);
+      connectionConfigurer = new NativeConnectionConfigurer(sessionManager);
+    } catch (Exception e) {
+      System.err.println("Initialization error: " + e.getMessage());
+      System.exit(1);
+    }
+  }
+
+  private static Optional<Thread> startReactor() {
+    try {
+      Thread connectionThread = new Reactor(serverSocket, connectionConfigurer, THREAD_POOL_SIZE);
+      connectionThread.start();
+      return Optional.of(connectionThread);
+    } catch (Exception e) {
+      System.err.println("Error starting reactor thread: " + e.getMessage());
+      System.exit(1);
+    }
+    return Optional.empty();
+  }
+
+  private static void startMonitorThread() {
+    Thread monitorThread = new Thread(threadGroup, new ThreadMonitor());
+    monitorThread.setDaemon(true);
+    monitorThread.start();
+  }
+
+  private static void killAllActiveThreads() {
+    threadGroup.interrupt();
+  }
+
+  private static void closeServerSocket() {
+    try {
+      serverSocket.close();
+    } catch (Exception e) {
+      System.err.println("Error closing server socket: " + e.getMessage());
+    }
+  }
+
+  private static class ThreadMonitor implements Runnable {
+    @Override
+    public void run() {
+      while (true) {
+        try {
+          Thread.sleep(MONITOR_SLEEP_DURATION_MS);
+          System.out.println();
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+        System.out.println("Active threads: " + Thread.activeCount());
+        Map<Thread, StackTraceElement[]> allThreads = Thread.getAllStackTraces();
+        for (Thread thread : allThreads.keySet()) {
+          System.out.println("Thread name: " + thread.getName() + ", State: " + thread.getState());
+        }
+      }
+    }
   }
 }

--- a/server/src/main/java/org/kunp/Main.java
+++ b/server/src/main/java/org/kunp/Main.java
@@ -2,14 +2,19 @@ package org.kunp;
 
 import static org.kunp.ServerConstant.*;
 
+import java.io.OutputStream;
 import java.net.ServerSocket;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.kunp.Servlet.*;
 import org.kunp.Servlet.session.*;
 
 public class Main {
 
   public static final ThreadGroup threadGroup = new ThreadGroup("ActiveThreads");
+  private static final List<OutputStream> outputStreams = new CopyOnWriteArrayList<>();
+  private static final GameContext gc = new GameContext();
   private static ServerSocket serverSocket;
   private static SessionStorage sessionStorage;
   private static ISessionIdGenerator sessionIdGenerator;
@@ -31,6 +36,8 @@ public class Main {
       closeServerSocket();
     }
   }
+
+  public static GameContext getGameContext() {return gc;}
 
   private static void initDependencies() {
     try {

--- a/server/src/main/java/org/kunp/Main.java
+++ b/server/src/main/java/org/kunp/Main.java
@@ -3,7 +3,6 @@ package org.kunp;
 import static org.kunp.ServerConstant.*;
 
 import java.net.ServerSocket;
-import java.util.Map;
 import java.util.Optional;
 import org.kunp.Servlet.*;
 import org.kunp.Servlet.session.*;
@@ -84,13 +83,9 @@ public class Main {
           Thread.sleep(MONITOR_SLEEP_DURATION_MS);
           System.out.println();
         } catch (InterruptedException e) {
-          e.printStackTrace();
         }
         System.out.println("Active threads: " + Thread.activeCount());
-        Map<Thread, StackTraceElement[]> allThreads = Thread.getAllStackTraces();
-        for (Thread thread : allThreads.keySet()) {
-          System.out.println("Thread name: " + thread.getName() + ", State: " + thread.getState());
-        }
+        System.out.println("Active Sessions : " + sessionStorage.size());
       }
     }
   }

--- a/server/src/main/java/org/kunp/ServerConstant.java
+++ b/server/src/main/java/org/kunp/ServerConstant.java
@@ -1,0 +1,9 @@
+package org.kunp;
+
+public final class ServerConstant {
+  public static final int SERVER_PORT = 8080;
+  public static final String SERVER_HOST = "localhost";
+
+  public static final int MONITOR_SLEEP_DURATION_MS = 5000;
+  public static final int THREAD_POOL_SIZE = 10;
+}

--- a/server/src/main/java/org/kunp/Servlet/ClientHandler.java
+++ b/server/src/main/java/org/kunp/Servlet/ClientHandler.java
@@ -1,0 +1,76 @@
+package org.kunp.Servlet;
+
+import java.io.*;
+
+/**
+ * Handles individual client requests in a separate thread.
+ *
+ * <p>This class reads input from the client, processes it, and writes the response back to the
+ * client. It also handles the disconnection of the client and notifies the callback.
+ */
+public class ClientHandler implements Runnable {
+
+  private final String sessionId;
+  private final BufferedInputStream inputStream;
+  private final BufferedOutputStream outputStream;
+  private final SocketDisconnectCallback callback;
+
+  /**
+   * Constructs a new ClientHandler.
+   *
+   * @param ios the input stream from the client
+   * @param oos the output stream to the client
+   * @param sessionId the session ID for the client
+   * @param callback the callback to notify when the client disconnects
+   */
+  public ClientHandler(
+      InputStream ios, OutputStream oos, String sessionId, SocketDisconnectCallback callback) {
+    this.sessionId = sessionId;
+    this.inputStream = new BufferedInputStream(ios);
+    this.outputStream = new BufferedOutputStream(oos);
+    this.callback = callback;
+  }
+
+  /**
+   * Runs the client handler thread.
+   *
+   * <p>This method reads input from the client, processes it, and writes the response back to the
+   * client. It also handles the disconnection of the client and notifies the callback.
+   */
+  @Override
+  public void run() {
+    System.out.println("Session ID: " + this.sessionId);
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
+      processClientRequests(br);
+    } catch (IOException e) {
+      System.err.println("Client disconnected or an error occurred: " + e.getMessage());
+    } finally {
+      closeResources();
+    }
+  }
+
+  private void processClientRequests(BufferedReader br) throws IOException {
+    String line;
+    while ((line = br.readLine()) != null) {
+      System.out.println("Received: " + line);
+      writeToOutputStream(line);
+    }
+  }
+
+  private void writeToOutputStream(String line) throws IOException {
+    outputStream.write((line + "\n").getBytes());
+    outputStream.flush();
+  }
+
+  private void closeResources() {
+    try {
+      inputStream.close();
+      outputStream.close();
+      if (callback != null) {
+        callback.onDisconnect(sessionId);
+      }
+    } catch (IOException e) {
+      System.err.println("Error closing streams: " + e.getMessage());
+    }
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/ConnectionConfigurer.java
+++ b/server/src/main/java/org/kunp/Servlet/ConnectionConfigurer.java
@@ -1,0 +1,20 @@
+package org.kunp.Servlet;
+
+import java.io.IOException;
+import java.net.Socket;
+import org.kunp.Servlet.session.SessionManager;
+
+public abstract class ConnectionConfigurer {
+  protected SessionManager sessionManager;
+
+  public ConnectionConfigurer(SessionManager sessionManager) {
+    this.sessionManager = sessionManager;
+  }
+
+  /***
+   * Configure the connection
+   * @param socket
+   * @return sessionId
+   */
+  public abstract Runnable configure(Socket socket) throws IOException;
+}

--- a/server/src/main/java/org/kunp/Servlet/GameContext.java
+++ b/server/src/main/java/org/kunp/Servlet/GameContext.java
@@ -1,0 +1,52 @@
+package org.kunp.Servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.kunp.Servlet.message.Message;
+import org.kunp.Servlet.session.Session;
+
+//TODO : thread로 따로 빼기
+public class GameContext {
+
+  private final Map<String, OutputStream> participants = new ConcurrentHashMap<>();
+  private int roomId;
+
+  public void enter(Session session) {
+    participants.put(session.getSessionId(), (OutputStream) session.getAttributes().get("ops"));
+  }
+
+  public void leave(Session session) {
+    participants.remove(session.getSessionId());
+  }
+  
+  public void broadcast(Message message) {
+    List<KV> streams = participants.entrySet().stream().map(e -> new KV(e.getKey(), e.getValue())).toList();
+    for(KV keyVal : streams) {
+      try {
+        keyVal.outputStream.write((message + "\n").getBytes(StandardCharsets.UTF_8));
+        keyVal.outputStream.flush();
+      } catch (SocketException e) {
+        participants.remove(keyVal.key);
+      } catch (IOException e) {
+        //throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private final class KV {
+    String key;
+    OutputStream outputStream;
+
+    public KV(String key, OutputStream outputStream) {
+      this.key = key;
+      this.outputStream = outputStream;
+    }
+  }
+}
+
+

--- a/server/src/main/java/org/kunp/Servlet/NativeConnectionConfigurer.java
+++ b/server/src/main/java/org/kunp/Servlet/NativeConnectionConfigurer.java
@@ -1,0 +1,29 @@
+package org.kunp.Servlet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import org.kunp.Servlet.session.Session;
+import org.kunp.Servlet.session.SessionManager;
+
+public class NativeConnectionConfigurer extends ConnectionConfigurer {
+
+  public NativeConnectionConfigurer(SessionManager sessionManager) {
+    super(sessionManager);
+  }
+
+  @Override
+  public Runnable configure(Socket socket) throws IOException {
+    Session createdSession = sessionManager.createSession();
+    InputStream inputStream = socket.getInputStream();
+    OutputStream outputStream = socket.getOutputStream();
+    Runnable clientHandler =
+        new ClientHandler(
+            inputStream,
+            outputStream,
+            createdSession.getSessionId(),
+            sessionId -> sessionManager.removeSession(sessionId));
+    return clientHandler;
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/NativeConnectionConfigurer.java
+++ b/server/src/main/java/org/kunp/Servlet/NativeConnectionConfigurer.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kunp.Main;
 import org.kunp.Servlet.session.Session;
 import org.kunp.Servlet.session.SessionManager;
 
@@ -18,12 +22,18 @@ public class NativeConnectionConfigurer extends ConnectionConfigurer {
     Session createdSession = sessionManager.createSession();
     InputStream inputStream = socket.getInputStream();
     OutputStream outputStream = socket.getOutputStream();
+
+    Map<String, Object> attr = new HashMap<>();
+    attr.put("ops", outputStream);
+    createdSession.setAttributes(attr);
+
+    Main.getGameContext().enter(createdSession);
     Runnable clientHandler =
         new ClientHandler(
             inputStream,
             outputStream,
-            createdSession.getSessionId(),
-            sessionId -> sessionManager.removeSession(sessionId));
+            createdSession,
+            sessionId -> sessionManager.removeSession(createdSession.getSessionId()));
     return clientHandler;
   }
 }

--- a/server/src/main/java/org/kunp/Servlet/Reactor.java
+++ b/server/src/main/java/org/kunp/Servlet/Reactor.java
@@ -1,0 +1,47 @@
+package org.kunp.Servlet;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Reactor class to handle incoming connections and dispatch them to the appropriate handler using a
+ * thread pool.
+ *
+ * <p>This is an initial implementation of the Reactor pattern.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Reactor_pattern">Reactor pattern</a>
+ * @see ExecutorService
+ */
+public class Reactor extends Thread {
+
+  private final ServerSocket serverSocket;
+  private final ConnectionConfigurer connectionConfigurer;
+  private final ExecutorService threadPool;
+
+  public Reactor(
+      ServerSocket serverSocket, ConnectionConfigurer connectionConfigurer, int poolSize) {
+    this.serverSocket = serverSocket;
+    this.connectionConfigurer = connectionConfigurer;
+    this.threadPool = Executors.newFixedThreadPool(poolSize);
+  }
+
+  @Override
+  public void run() {
+    waitForConnection();
+  }
+
+  private void waitForConnection() {
+    while (true) {
+      try {
+        Socket socket = serverSocket.accept();
+        Runnable clientHandler = connectionConfigurer.configure(socket);
+        threadPool.execute(clientHandler);
+      } catch (IOException e) {
+        throw new RuntimeException("Error occurred while waiting for connection", e);
+      }
+    }
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/SocketDisconnectCallback.java
+++ b/server/src/main/java/org/kunp/Servlet/SocketDisconnectCallback.java
@@ -1,0 +1,6 @@
+package org.kunp.Servlet;
+
+/** Callback for event when Socket connection is closed */
+public interface SocketDisconnectCallback {
+  void onDisconnect(String sessionId);
+}

--- a/server/src/main/java/org/kunp/Servlet/aop/CatchGlobally.java
+++ b/server/src/main/java/org/kunp/Servlet/aop/CatchGlobally.java
@@ -1,0 +1,10 @@
+package org.kunp.Servlet.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CatchGlobally {}

--- a/server/src/main/java/org/kunp/Servlet/aop/ErrorHandlingAspect.java
+++ b/server/src/main/java/org/kunp/Servlet/aop/ErrorHandlingAspect.java
@@ -1,0 +1,27 @@
+package org.kunp.Servlet.aop;
+
+import java.lang.reflect.Method;
+
+public class ErrorHandlingAspect {
+  public static void handleError(Exception e) {
+    System.err.println("Error occurred: " + e.getMessage());
+  }
+
+  public static void invokeWithHandling(Object obj, String methodName) {
+    try {
+      Method method = obj.getClass().getMethod(methodName);
+      if (method.isAnnotationPresent(CatchGlobally.class)) {
+        try {
+          method.invoke(obj);
+        } catch (Exception e) {
+          handleError(e);
+          System.out.println("핸들러");
+        }
+      } else {
+        method.invoke(obj);
+      }
+    } catch (Exception e) {
+      handleError(e);
+    }
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/message/Message.java
+++ b/server/src/main/java/org/kunp/Servlet/message/Message.java
@@ -1,0 +1,59 @@
+package org.kunp.Servlet.message;
+
+import java.io.Serializable;
+
+public class Message implements Serializable {
+  private final int type; // 1. 움직임, 2. 상호작용
+  private final int id;
+  private final int x;
+  private int y;
+  private int roomNumber;
+
+  public Message(int type, int id, int x, int y, int roomNumber) {
+    this.type = type;
+    this.id = id;
+    this.x = x;
+    this.y = y;
+    this.roomNumber = roomNumber;
+  }
+
+  /***
+   * parsing String message to Message obj
+   * @param message String
+   * @return Message
+   */
+  public static Message parse(String message) {
+    String[] tokens = message.split("\\|");
+    return new Message(
+        Integer.parseInt(tokens[0]),
+        Integer.parseInt(tokens[1]),
+        Integer.parseInt(tokens[2]),
+        Integer.parseInt(tokens[3]),
+        Integer.parseInt(tokens[4]));
+  }
+
+  public int getType() {
+    return type;
+  }
+
+  public int getY() {
+    return y;
+  }
+
+  public void setY(int y) {
+    this.y = y;
+  }
+
+  public int getRoomNumber() {
+    return roomNumber;
+  }
+
+  public void setRoomNumber(int roomNumber) {
+    this.roomNumber = roomNumber;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%d|%d|%d|%d|%d", type, id, x, y, roomNumber);
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/session/ISessionIdGenerator.java
+++ b/server/src/main/java/org/kunp/Servlet/session/ISessionIdGenerator.java
@@ -1,0 +1,5 @@
+package org.kunp.Servlet.session;
+
+public interface ISessionIdGenerator {
+  String generateSessionId();
+}

--- a/server/src/main/java/org/kunp/Servlet/session/Session.java
+++ b/server/src/main/java/org/kunp/Servlet/session/Session.java
@@ -1,0 +1,70 @@
+package org.kunp.Servlet.session;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.kunp.ValidateUtils;
+
+public class Session implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private final transient long creationTime;
+  private final transient long lastAccessedTime;
+  private String sessionId;
+  private Map<String, Object> attributes;
+
+  /***
+   * Constructor for session
+   * @param sessionId
+   * @param attributes
+   * @param creationTime
+   * @param lastAccessedTime
+   */
+  private Session(
+      String sessionId, Map<String, Object> attributes, long creationTime, long lastAccessedTime) {
+    this.sessionId = sessionId;
+    this.attributes = attributes;
+    this.creationTime = creationTime;
+    this.lastAccessedTime = lastAccessedTime;
+  }
+
+  /***
+   * Factory method for Empty session
+   * @return Session object
+   */
+  public static Session createEmptySession() {
+    return new Session(null, null, 0, 0);
+  }
+
+  /***
+   * getter for creation time
+   * @return sessionId
+   */
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  /***
+   *  setter for session id
+   * @param sessionId not null
+   */
+  public void setSessionId(String sessionId) {
+    ValidateUtils.notNull(sessionId, "SessionId cannot be null");
+    this.sessionId = sessionId;
+  }
+
+  /***
+   * getter for Attributes
+   * @return Map<String, Object> attributes
+   */
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  /***
+   * setter for session attributes
+   * @param attributes Map<String, Object> not null
+   */
+  public void setAttributes(Map<String, Object> attributes) {
+    ValidateUtils.notNull(attributes, "Attributes cannot be null");
+    this.attributes = attributes;
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/session/SessionIdGenerator.java
+++ b/server/src/main/java/org/kunp/Servlet/session/SessionIdGenerator.java
@@ -1,0 +1,17 @@
+package org.kunp.Servlet.session;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class SessionIdGenerator implements ISessionIdGenerator {
+
+  private static final SecureRandom secureRandom = new SecureRandom();
+  private static final Base64.Encoder base64Encoder = Base64.getUrlEncoder().withoutPadding();
+
+  @Override
+  public String generateSessionId() {
+    byte[] randomBytes = new byte[16];
+    secureRandom.nextBytes(randomBytes);
+    return base64Encoder.encodeToString(randomBytes);
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/session/SessionInMemoryStorage.java
+++ b/server/src/main/java/org/kunp/Servlet/session/SessionInMemoryStorage.java
@@ -1,0 +1,29 @@
+package org.kunp.Servlet.session;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SessionInMemoryStorage implements SessionStorage {
+
+  private final Map<String, Session> sessionMap = new ConcurrentHashMap<>();
+
+  @Override
+  public void save(String key, Object value) {
+    sessionMap.put(key, (Session) value);
+  }
+
+  @Override
+  public Object get(String key) {
+    return sessionMap.get(key);
+  }
+
+  @Override
+  public void remove(String key) {
+    sessionMap.remove(key);
+  }
+
+  @Override
+  public void clear() {
+    sessionMap.clear();
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/session/SessionInMemoryStorage.java
+++ b/server/src/main/java/org/kunp/Servlet/session/SessionInMemoryStorage.java
@@ -26,4 +26,9 @@ public class SessionInMemoryStorage implements SessionStorage {
   public void clear() {
     sessionMap.clear();
   }
+
+  @Override
+  public int size() {
+    return sessionMap.size();
+  }
 }

--- a/server/src/main/java/org/kunp/Servlet/session/SessionManager.java
+++ b/server/src/main/java/org/kunp/Servlet/session/SessionManager.java
@@ -1,0 +1,34 @@
+package org.kunp.Servlet.session;
+
+import static org.kunp.Servlet.session.Session.createEmptySession;
+
+public class SessionManager {
+
+  private final SessionStorage sessionStorage;
+  private final ISessionIdGenerator sessionIdGenerator;
+
+  public SessionManager(SessionStorage sessionStorage, ISessionIdGenerator sessionIdGenerator) {
+    this.sessionStorage = sessionStorage;
+    this.sessionIdGenerator = sessionIdGenerator;
+  }
+
+  public Session createSession() {
+    Session session = createEmptySession();
+    String sessionId = sessionIdGenerator.generateSessionId();
+    session.setSessionId(sessionId);
+    sessionStorage.save(sessionId, session);
+    return session;
+  }
+
+  public Session getSession(String sessionId) {
+    return (Session) sessionStorage.get(sessionId);
+  }
+
+  public void removeSession(String sessionId) {
+    sessionStorage.remove(sessionId);
+  }
+
+  public void clear() {
+    sessionStorage.clear();
+  }
+}

--- a/server/src/main/java/org/kunp/Servlet/session/SessionStorage.java
+++ b/server/src/main/java/org/kunp/Servlet/session/SessionStorage.java
@@ -8,4 +8,6 @@ public interface SessionStorage {
   void remove(String key);
 
   void clear();
+
+  int size();
 }

--- a/server/src/main/java/org/kunp/Servlet/session/SessionStorage.java
+++ b/server/src/main/java/org/kunp/Servlet/session/SessionStorage.java
@@ -1,0 +1,11 @@
+package org.kunp.Servlet.session;
+
+public interface SessionStorage {
+  void save(String key, Object value);
+
+  Object get(String key);
+
+  void remove(String key);
+
+  void clear();
+}

--- a/server/src/main/java/org/kunp/ValidateUtils.java
+++ b/server/src/main/java/org/kunp/ValidateUtils.java
@@ -1,0 +1,16 @@
+package org.kunp;
+
+public final class ValidateUtils {
+
+  public static void notNull(Object object, String message) {
+    if (object == null) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  public static void notEmpty(String target) {
+    if (target == null || target.isEmpty()) {
+      throw new IllegalArgumentException(target);
+    }
+  }
+}

--- a/server/src/test/java/org/kunp/ConnectionTest.java
+++ b/server/src/test/java/org/kunp/ConnectionTest.java
@@ -1,0 +1,72 @@
+package org.kunp;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.lang.Thread.sleep;
+
+class ConnectionTest {
+
+
+  @BeforeAll
+  static void startServer() throws IOException {
+    ProcessBuilder processBuilder = new ProcessBuilder("java", "-cp", "build/classes/java/main", "org.kunp.Main");
+    processBuilder.inheritIO();
+    processBuilder.start();
+    // Wait for the server to start
+    try {
+      sleep(10000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+  @AfterAll
+  static void stopServer() {
+    // Kill the server
+    try {
+      ProcessBuilder processBuilder = new ProcessBuilder("pkill", "-f", "org.kunp.Main");
+      processBuilder.start();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  @DisplayName("Accept connections from multiple Clients")
+  void testAcceptConnections() throws InterruptedException {
+    Runnable client =
+        () -> {
+          try {
+            Socket socket = new Socket(ServerConstant.SERVER_HOST, ServerConstant.SERVER_PORT);
+            synchronized (this) {
+              wait();
+            }
+            System.out.println("Client Disconnected");
+          } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          } catch (InterruptedException e) {
+            System.out.println("Client Interrupted");
+          }
+        };
+
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    for (int i = 0; i < 10; i++) {
+      executorService.execute(client);
+    }
+    sleep(5000);
+    synchronized (client) {
+      client.notifyAll();
+    }
+    executorService.shutdown();
+  }
+}

--- a/server/src/test/java/org/kunp/ConnectionTest.java
+++ b/server/src/test/java/org/kunp/ConnectionTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.concurrent.ExecutorService;
@@ -41,25 +44,13 @@ class ConnectionTest {
 
   @Test
   @DisplayName("Accept connections from multiple Clients")
-  void testAcceptConnections() throws InterruptedException {
-    Runnable client =
-        () -> {
-          try {
-            Socket socket = new Socket(ServerConstant.SERVER_HOST, ServerConstant.SERVER_PORT);
-            synchronized (this) {
-              wait();
-            }
-            System.out.println("Client Disconnected");
-          } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          } catch (InterruptedException e) {
-            System.out.println("Client Interrupted");
-          }
-        };
+  void testAcceptConnections() throws InterruptedException, IOException {
+    Socket socket = new Socket("localhost", 8080);
+
 
     ExecutorService executorService = Executors.newFixedThreadPool(10);
+    Runnable client
+        = null;
     for (int i = 0; i < 10; i++) {
       executorService.execute(client);
     }


### PR DESCRIPTION
### 작업내역

- TCP 요청을 처리하는 핸들러 작성
- 각 요청마다 서버에서 세션을 유지하는 기능 구현
  - JVM in-heap에 세션 데이터를 저장
  - 커넥션이 종료되면 세션 데이터도 삭제

### 리뷰어에게 전달할 내용
- 스켈레톤 코드를 작성했습니다.
- 현재 String을 입력받으면 출력하는 Echo 서버 기능을 담당합니다.
- 한번에 유지할 수 있는 커넥션은 최대 10개로 고정했습니다.
- 블로킹 I/O를 사용하고 있습니다. 추후 NIO로 교체할 예정입니다. 

### 트러블 슈팅
- 클라이언트에서 요청을 끊게되면 NIO를 사용하지 않는 현재로서는 `InputStream`의 `read` 를 통해 커넥션이 만료된것을 파악해야합니다.