### PR TITLE
feat/client/sync-locations

### DIFF
--- a/client/src/main/java/org/kunp/Client.java
+++ b/client/src/main/java/org/kunp/Client.java
@@ -13,14 +13,15 @@ public class Client {
     private String sessionId;
     private Player player;
 
-    public Client() {
+    public Client(String TempSessionId) {
         try {
             socket = new Socket(SERVER_HOST, SERVER_PORT);
             out = new PrintWriter(socket.getOutputStream(), true);
             in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            sessionId = TempSessionId;
 
             // 서버로부터 세션 ID 받음 -> 24.11.01 3시 기준 서버 구현 미완료로 현재 에러 발생
-            sessionId = in.readLine();
+            // sessionId = in.readLine();
             System.out.println("Connected with session ID: " + sessionId);
         } catch (IOException e) {
             e.printStackTrace();
@@ -31,7 +32,7 @@ public class Client {
 
         JFrame frame = new JFrame("Tag Game");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        Map map = new Map(out, player, sessionId);
+        Map map = new Map(in, out, player, sessionId);
         frame.add(map);
         frame.pack();
         frame.setVisible(true);

--- a/client/src/main/java/org/kunp/Location.java
+++ b/client/src/main/java/org/kunp/Location.java
@@ -1,0 +1,24 @@
+package org.kunp;
+
+public class Location{
+    int roomNumber, x, y;
+    public Location(int roomNumber, int x, int y){
+        this.roomNumber = roomNumber;
+        this.x = x;
+        this.y = y;
+    }
+    public void setLocation(int roomNumber, int x, int y){
+        this.roomNumber = roomNumber;
+        this.x = x;
+        this.y = y;
+    }
+    public int getRoomNumber(){
+        return roomNumber;
+    }
+    public int getX(){
+        return x;
+    }
+    public int getY(){
+        return y;
+    }
+}

--- a/client/src/main/java/org/kunp/Main.java
+++ b/client/src/main/java/org/kunp/Main.java
@@ -1,16 +1,16 @@
 package org.kunp;
-
 import javax.swing.*;
 
 public class Main {
-  public static void main(String[] args) {
-    SwingUtilities.invokeLater(() -> {
-      try {
-        new Client();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-    });
-  }
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                String TempSessionId = args[0];
+                new Client(TempSessionId);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
 }
 

--- a/client/src/main/java/org/kunp/Map.java
+++ b/client/src/main/java/org/kunp/Map.java
@@ -3,28 +3,35 @@ package org.kunp;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
-import java.io.PrintWriter;
+import java.io.*;
+import java.util.HashMap;
 
 public class Map extends JPanel {
+    private static final int MAP_SIZE = 500;
     private static final int VIEW_SIZE = 500;
     private static final int MOVE_STEP = 10;
+    private static final int CELL_SIZE = 10;
     private MapPanel[][] maps;
     private int currentMapX = 1, currentMapY = 1;
     private final Player player;
     private final boolean[] keysPressed = new boolean[256]; // 키 상태 추적용 배열
     private final Timer moveTimer;
+    private final BufferedReader in;
     private final PrintWriter out;
     private final String sessionId;
+    private final HashMap<String, Location> locations = new HashMap<>();
 
-    public Map(PrintWriter out, Player player, String sessionId) {
+    public Map(BufferedReader in, PrintWriter out, Player player, String sessionId) {
+        this.in = in;
         this.out = out;
         this.player = player;
         this.sessionId = sessionId;
+
         setPreferredSize(new Dimension(VIEW_SIZE, VIEW_SIZE));
         setFocusable(true);
         initializeMapPanels();
 
-        /* 방향키를 눌렀을 때 이동에 지연어 없도록 하기위함 */
+        // 방향키 입력에 즉각적으로 반응하도록
         addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
@@ -36,20 +43,41 @@ public class Map extends JPanel {
             }
         });
 
-        // Timer 설정: 50ms 마다 유저의 키 상태를 체크
+        // FocusListener 추가
+        addFocusListener(new FocusListener() {
+            @Override
+            public void focusLost(FocusEvent e) {
+                // 모든 키 상태를 false로 초기화
+                for (int i = 0; i < keysPressed.length; i++) {
+                    keysPressed[i] = false;
+                }
+            }
+            @Override
+            public void focusGained(FocusEvent e) {
+                // 포커스를 얻었을 때의 동작이 필요 없다면 비워둡니다.
+            }
+        });
+
+        // 50ms마다 유저의 키 상태를 체크
         moveTimer = new Timer(50, e -> checkMovement());
         moveTimer.start();
-
         requestFocusInWindow();
+
+        // 서버로부터 동일한 맵에 유저들의 위치 정보를 받아 화면을 업데이트
+        PositionSyncThread pst = new PositionSyncThread(in);
+        pst.start();
     }
 
     private void initializeMapPanels() {
         maps = new MapPanel[3][3];
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                maps[i][j] = new MapPanel(i, j, player);
+                maps[i][j] = new MapPanel(i, j, player, locations);
             }
         }
+        // 유저 자기 자신을 추가
+        player.move(VIEW_SIZE / 2 - player.getX(), VIEW_SIZE / 2 - player.getY());
+        //maps[currentMapX][currentMapY].updateLocInfo(sessionId, player.getX(), player.getY());
         setLayout(new BorderLayout());
         add(maps[currentMapX][currentMapY], BorderLayout.CENTER);
     }
@@ -78,15 +106,15 @@ public class Map extends JPanel {
                 break;
         }
 
-        //portal 이동 감지 후 서버에게 room number 변경해서 보냄
+        // portal 이동 감지 후 서버에게 room number 변경해서 보냄
         int portal;
         if ((portal = maps[currentMapX][currentMapY].isPortal(newX, newY)) != -1) {
             moveMap(newX, newY, portal);
         } else {
             player.move(newX - player.getX(), newY - player.getY());
-            repaint();
+            //repaint();
         }
-        updateLocationLabel();
+        // updateLocationLabel();
     }
 
     private void moveMap(int x, int y, int portal) {
@@ -99,16 +127,50 @@ public class Map extends JPanel {
         remove(maps[currentMapX][currentMapY]);
         currentMapX = newX;
         currentMapY = newY;
-        player.move(VIEW_SIZE / 2 - player.getX(), VIEW_SIZE / 2 - player.getY());
         player.setRoomNumber(newY * 3 + newX + 1);
+
+        int portalSize = CELL_SIZE * 5;
+        if (portal == 2) player.move(MAP_SIZE - 2*portalSize - player.getImageSizeX() - 10, 0);
+        if (portal == 3) player.move(-MAP_SIZE + 2*portalSize + 10, 0);
+        if (portal == 0) player.move(0, MAP_SIZE - 2*portalSize - player.getImageSizeY());
+        if (portal == 1) player.move(0, -MAP_SIZE + 2*portalSize + player.getImageSizeY());
         add(maps[currentMapX][currentMapY], BorderLayout.CENTER);
         revalidate();
-        repaint();
+        //repaint();
         requestFocusInWindow();
-        updateLocationLabel();
+        //updateLocationLabel();
     }
 
     private void updateLocationLabel() {
         System.out.println("현재 맵: (" + currentMapX + ", " + currentMapY + ") | 플레이어 위치: (" + player.getX() + ", " + player.getY() + ") | Room Number: " + player.getRoomNumber());
+    }
+
+    private class PositionSyncThread extends Thread{
+        private BufferedReader in = null;
+        public PositionSyncThread(BufferedReader in){
+            this.in = in;
+        }
+        public void run(){
+            try {
+                String line = null;
+                while ((line = in.readLine()) != null) {
+                    String[] parts = line.split("\\|");
+                    String sessionId = parts[1];
+                    int x = Integer.parseInt(parts[2]);
+                    int y = Integer.parseInt(parts[3]);
+                    int roomNumber = Integer.parseInt(parts[4]);
+                    synchronized (locations){
+                        if(locations.containsKey(sessionId) == false) locations.put(sessionId, new Location(roomNumber, x, y));
+                        else locations.get(sessionId).setLocation(roomNumber, x, y);
+                    }
+                    repaint();
+                }
+            }catch(Exception ex){
+            }finally{
+                try{
+                    if(in != null) in.close();
+                }catch(Exception ex){}
+            }
+        }
     }
 }

--- a/client/src/main/java/org/kunp/MapPanel.java
+++ b/client/src/main/java/org/kunp/MapPanel.java
@@ -4,7 +4,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.util.Objects;
+import java.util.*;
 
 public class MapPanel extends JPanel {
     private static final int MAP_SIZE = 500;
@@ -13,11 +13,16 @@ public class MapPanel extends JPanel {
     private Rectangle[] portals;
     private Image portalImage;
     private Player player;
+    private Image image = new ImageIcon(Objects.requireNonNull(getClass().getResource("/tagger.png"))).getImage();
+    private static final int IMAGE_SIZE_X = 30;
+    private static final int IMAGE_SIZE_Y = 50;
+    private HashMap<String, Location> locations = null;
 
-    public MapPanel(int mapX, int mapY, Player player) {
+    public MapPanel(int mapX, int mapY, Player player, HashMap<String, Location> locations) {
         this.mapX = mapX;
         this.mapY = mapY;
         this.player = player;
+        this.locations = locations;
         setPreferredSize(new Dimension(MAP_SIZE, MAP_SIZE));
         setFocusable(true);
         initializePortals();
@@ -40,7 +45,7 @@ public class MapPanel extends JPanel {
                         player.move(CELL_SIZE, 0);
                         break;
                 }
-                repaint();
+                //repaint();
             }
         });
     }
@@ -65,6 +70,7 @@ public class MapPanel extends JPanel {
         super.paintComponent(g);
         drawMap(g);
         drawPlayer(g);
+        drawCoMapUsers(g);
     }
 
     private void drawMap(Graphics g) {
@@ -86,9 +92,23 @@ public class MapPanel extends JPanel {
         player.draw(g);
     }
 
+    private void drawCoMapUsers(Graphics g) {
+        synchronized (locations) {
+            Collection collection = locations.values();
+            Iterator iter = collection.iterator();
+            while(iter.hasNext()){
+                Location loc = (Location) iter.next();
+                if(loc.getRoomNumber() == mapY * 3 + mapX + 1){
+                    g.drawImage(image, loc.getX(), loc.getY(), IMAGE_SIZE_X, IMAGE_SIZE_Y, null);
+                }
+            }
+        }
+    }
+
     public int isPortal(int x, int y) {
+        Rectangle portalRange = new Rectangle(x, y, 1, IMAGE_SIZE_Y);
         for (int i = 0; i < portals.length; i++) {
-            if (portals[i] != null && portals[i].contains(x, y)) {
+            if (portals[i] != null && portals[i].intersects(portalRange)) {
                 return i;
             }
         }

--- a/client/src/main/java/org/kunp/Player.java
+++ b/client/src/main/java/org/kunp/Player.java
@@ -28,31 +28,24 @@ public class Player {
     public int getX() {
         return x;
     }
-
     public int getY() {
         return y;
     }
-
     public int getImageSizeX() {
         return IMAGE_SIZE_X;
     }
-
     public int getImageSizeY() {
         return IMAGE_SIZE_Y;
     }
-
     public String getRole() {
         return role;
     }
-
     public String getSessionId() {
         return sessionId;
     }
-
     public int getRoomNumber() {
         return roomNumber;
     }
-
     public void setRoomNumber(int roomNumber) {
         this.roomNumber = roomNumber;
     }


### PR DESCRIPTION
## 🐣Title
[Feat/client/sync-locations]
---

<br/>

## 🐣Part
Client
---

<br/>

## 🐣Key Changes
1. 같은 맵에 있는 유저들이 움직이거나 맵을 이동하는 것이 동기화합니다.
2. Location.java: 각 유저의 위치(roomNumber, x, y)를 저장하는 간단한 객체입니다.
3. Map.java
* 방향키를 누른 채 Swing 창을 비활성화시키면 마지막 방향키대로 계속 움직이는 버그를 발견하였고, 이를 해결하기 위해 FocusListener를 달아서 Swing이 비활성화 된 순간 방향키를 false 상태로 만듭니다.
* 서버의 브로드캐스팅을 받는 역할을 하는 PositionSyncThread를 구현했습니다. 또한, Swing의 repaint는 오직 브로드캐스팅 정보가 들어왔을 때만 하도록 수정했습니다 (즉, 자기 자신의 움직임도 서버가 브로드캐스팅한 정보를 이용하여 repaint)
* 키가 sessionId, 밸류가 Location 객체(roomNumber, x, y)인 맵 자료구조인 locations를 구현했습니다. locations은 서버의 브로드캐스팅 정보로 업데이트됩니다. 각 유저마다 locations에 있는 유저 중에서 현재 같은 맵에 있는 유저만 화면에 그립니다 (MapPanel의 drawCoMapUsers())
4. MapPanel.java
* 포탈 이동 판정이 약간 부정확한 경우가 있어서, 이동 판정을 좀 더 후하게 수정하였습니다 (포탈 그래픽에 닿으면 되는 정도)
* 포탈 이동시, 새로운 맵의 중앙이 아닌, 반대쪽 포탈에서 나오도록 수정했습니다.
---

<br/>

## 🐣Simulation

https://github.com/user-attachments/assets/af81a3f0-eab7-437c-8078-99a86f70a44e

클라이언트 3개도 해봤는데 잘 되는 것을 확인했습니다.

---

<br/>

## 🐣To Reviewer

---

<br/>

## 🐣Next
* 현재 서버에서 브로드캐스팅이 들어올 때마다 repaint를 하고 있는데, 추후 오버헤드가 너무 크다면 클라이언트에서 브로드캐스팅을 짧은 주기동안 모았다가 한꺼번에 repaint하는 방식을 고려할 수 있을 것 같습니다.
---

 <br/>

## 🐣Issue
* 서버가 클라이언트에게 sessionId를 보내주는 부분이 아직 미완성이라서, 임시방편으로 Client의 main.java를 실행할 때 args로 sessionId를 직접 지정해서 시뮬레이션 했습니다.
---


<br/>