### PR TITLE
[Fix/client/waitingroom-UI] 대기실 오류 및 게임 시작 수정

### DIFF
--- a/client/src/main/java/org/kunp/Client.java
+++ b/client/src/main/java/org/kunp/Client.java
@@ -63,7 +63,7 @@ public class Client {
         // 대기실 화면
         JPanel waitingRoomPanel = new JPanel(new BorderLayout());
         waitingRoomPanel.add(new WaitingRoomListPanel(sessionId, stateManager, serverCommunicator, screenManager), BorderLayout.CENTER);
-        waitingRoomPanel.add(new WaitingRoomCreationPanel(stateManager), BorderLayout.SOUTH);
+        waitingRoomPanel.add(new WaitingRoomCreationPanel(stateManager, screenManager, serverCommunicator), BorderLayout.SOUTH);
         screenManager.addScreen("WaitingRoom", waitingRoomPanel);
 
         // Map 화면 (게임 화면)

--- a/client/src/main/java/org/kunp/Client.java
+++ b/client/src/main/java/org/kunp/Client.java
@@ -1,5 +1,6 @@
 package org.kunp;
 
+import org.kunp.inner.InnerWaitingRoomComponent;
 import org.kunp.waiting.WaitingRoomCreationPanel;
 import org.kunp.waiting.WaitingRoomListPanel;
 
@@ -18,31 +19,54 @@ public class Client {
 
     public Client() {
         try {
+            // 서버와 연결
             socket = new Socket(SERVER_HOST, SERVER_PORT);
             out = new PrintWriter(socket.getOutputStream(), true);
             in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+
+            // 서버에서 세션 ID 수신
             sessionId = in.readLine();
             System.out.println("Connected with session ID: " + sessionId);
         } catch (IOException e) {
             e.printStackTrace();
+            JOptionPane.showMessageDialog(null, "서버 연결 실패: " + e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            return;
         }
 
+        // 화면 관리 및 상태 초기화
+        ScreenManager screenManager = new ScreenManager();
+        ServerCommunicator serverCommunicator = new ServerCommunicator(in, out);
+        StateManager stateManager = new StateManager(screenManager, serverCommunicator, sessionId);
+
+        // 프레임 설정
         JFrame frame = new JFrame("Tag Game - 대기실");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setSize(600, 500); // 화면 크기
         frame.setLayout(new BorderLayout());
-        frame.setSize(600, 500);  // 화면 크기를 키움
 
-        // 대기실 목록 패널
-        JPanel parentPanel = new JPanel(new BorderLayout());
-        WaitingRoomListPanel waitingRoomListPanel = new WaitingRoomListPanel(parentPanel, in, out, sessionId);
-        parentPanel.add(waitingRoomListPanel, BorderLayout.CENTER);
+        // 화면 등록
+        registerScreens(sessionId, screenManager, stateManager, serverCommunicator);
 
-        // 대기실 생성 패널
-        WaitingRoomCreationPanel waitingRoomCreationPanel = new WaitingRoomCreationPanel(parentPanel, in, out, sessionId);
-        parentPanel.add(waitingRoomCreationPanel, BorderLayout.SOUTH);
+        // 화면 전환
+        screenManager.showScreen("WaitingRoom");
 
-        frame.add(parentPanel, BorderLayout.CENTER);
+        frame.add(screenManager.getMainPanel(), BorderLayout.CENTER);
         frame.setVisible(true);
     }
-}
 
+    /**
+     * 화면 등록 메서드
+     * @param screenManager 화면 관리 객체
+     * @param stateManager 상태 관리 객체
+     */
+    private void registerScreens(String sessionId, ScreenManager screenManager, StateManager stateManager, ServerCommunicator serverCommunicator) {
+        // 대기실 화면
+        JPanel waitingRoomPanel = new JPanel(new BorderLayout());
+        waitingRoomPanel.add(new WaitingRoomListPanel(sessionId, stateManager, serverCommunicator, screenManager), BorderLayout.CENTER);
+        waitingRoomPanel.add(new WaitingRoomCreationPanel(stateManager), BorderLayout.SOUTH);
+        screenManager.addScreen("WaitingRoom", waitingRoomPanel);
+
+        // Map 화면 (게임 화면)
+        screenManager.addScreen("Map", new JPanel());
+    }
+}

--- a/client/src/main/java/org/kunp/Client.java
+++ b/client/src/main/java/org/kunp/Client.java
@@ -62,8 +62,8 @@ public class Client {
     private void registerScreens(String sessionId, ScreenManager screenManager, StateManager stateManager, ServerCommunicator serverCommunicator) {
         // 대기실 화면
         JPanel waitingRoomPanel = new JPanel(new BorderLayout());
-        waitingRoomPanel.add(new WaitingRoomListPanel(sessionId, stateManager, serverCommunicator, screenManager), BorderLayout.CENTER);
-        waitingRoomPanel.add(new WaitingRoomCreationPanel(stateManager, screenManager, serverCommunicator), BorderLayout.SOUTH);
+        waitingRoomPanel.add(new WaitingRoomListPanel(sessionId, stateManager, serverCommunicator, screenManager, in, out), BorderLayout.CENTER);
+        waitingRoomPanel.add(new WaitingRoomCreationPanel(stateManager, screenManager, serverCommunicator, in, out), BorderLayout.SOUTH);
         screenManager.addScreen("WaitingRoom", waitingRoomPanel);
 
         // Map 화면 (게임 화면)

--- a/client/src/main/java/org/kunp/ScreenManager.java
+++ b/client/src/main/java/org/kunp/ScreenManager.java
@@ -1,0 +1,27 @@
+package org.kunp;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class ScreenManager {
+    private final JPanel mainPanel;
+    private final CardLayout cardLayout;
+
+    public ScreenManager() {
+        this.cardLayout = new CardLayout();
+        this.mainPanel = new JPanel(cardLayout);
+    }
+
+    public JPanel getMainPanel() {
+        return mainPanel;
+    }
+
+    public void addScreen(String name, JPanel screen) {
+        mainPanel.add(screen, name);
+    }
+
+    public void showScreen(String name) {
+        cardLayout.show(mainPanel, name);
+    }
+}
+

--- a/client/src/main/java/org/kunp/ServerCommunicator.java
+++ b/client/src/main/java/org/kunp/ServerCommunicator.java
@@ -1,0 +1,54 @@
+package org.kunp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ServerCommunicator {
+    private final BufferedReader in;
+    private final PrintWriter out;
+    private final List<ServerMessageListener> listeners = new ArrayList<>();
+
+    public interface ServerMessageListener {
+        void onMessageReceived(String message);
+    }
+
+    public ServerCommunicator(BufferedReader in, PrintWriter out) {
+        this.in = in;
+        this.out = out;
+
+        // 서버 메시지 수신 스레드
+        new Thread(() -> {
+            try {
+                String message;
+                while ((message = in.readLine()) != null) {
+                    System.out.println(message);
+                    notifyListeners(message);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+    }
+
+    public void sendRequest(String message) {
+        out.println(message);
+        out.flush();
+    }
+
+    public void addMessageListener(ServerMessageListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeMessageListener(ServerMessageListener listener) {
+        listeners.remove(listener);
+    }
+
+    private void notifyListeners(String message) {
+        for (ServerMessageListener listener : listeners) {
+            listener.onMessageReceived(message);
+        }
+    }
+}

--- a/client/src/main/java/org/kunp/StateManager.java
+++ b/client/src/main/java/org/kunp/StateManager.java
@@ -36,15 +36,6 @@ public class StateManager {
     public void addMessageListener(ServerCommunicator.ServerMessageListener listener) {
         serverCommunicator.addMessageListener(listener);
     }
-
-    public void removeMessageListener(ServerCommunicator.ServerMessageListener listener) {
-        serverCommunicator.removeMessageListener(listener);
-    }
-
-    public void fetchRoomList(Runnable onSuccess) {
-        String request = "100|" + sessionId + "|null|0|0|1";  // 대기실 목록을 요청하는 메시지
-        sendServerRequest(request, onSuccess);
-    }
 }
 
 

--- a/client/src/main/java/org/kunp/StateManager.java
+++ b/client/src/main/java/org/kunp/StateManager.java
@@ -1,0 +1,50 @@
+package org.kunp;
+
+import javax.swing.*;
+
+public class StateManager {
+    private final ScreenManager screenManager;
+    private final ServerCommunicator serverCommunicator;
+    private final String sessionId;
+    private String currentScreen; // 현재 화면을 추적하는 필드 추가
+
+    public StateManager(ScreenManager screenManager, ServerCommunicator serverCommunicator, String sessionId) {
+        this.screenManager = screenManager;
+        this.serverCommunicator = serverCommunicator;
+        this.sessionId = sessionId;
+        this.currentScreen = ""; // 초기화
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void switchTo(String screenName) {
+        currentScreen = screenName; // 현재 화면 업데이트
+        SwingUtilities.invokeLater(() -> screenManager.showScreen(screenName));
+    }
+
+    public String getCurrentScreen() {
+        return currentScreen; // 현재 화면 반환
+    }
+
+    public void sendServerRequest(String request, Runnable onSuccess) {
+        serverCommunicator.sendRequest(request);
+        SwingUtilities.invokeLater(onSuccess);
+    }
+
+    public void addMessageListener(ServerCommunicator.ServerMessageListener listener) {
+        serverCommunicator.addMessageListener(listener);
+    }
+
+    public void removeMessageListener(ServerCommunicator.ServerMessageListener listener) {
+        serverCommunicator.removeMessageListener(listener);
+    }
+
+    public void fetchRoomList(Runnable onSuccess) {
+        String request = "100|" + sessionId + "|null|0|0|1";  // 대기실 목록을 요청하는 메시지
+        sendServerRequest(request, onSuccess);
+    }
+}
+
+

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -5,6 +5,7 @@ import org.kunp.StateManager;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,7 +30,6 @@ public class InnerWaitingRoomComponent extends JPanel {
 
     // 메시지 리스너 등록
     ServerCommunicator.ServerMessageListener listener = message -> {
-      System.out.println("inner message");
       handleServerMessage(stateManager, message, sessionIds, listPanel);
     };
 
@@ -41,19 +41,22 @@ public class InnerWaitingRoomComponent extends JPanel {
 
     if (tokens.length > 1) {
       String type = tokens[0];
-      System.out.println(type);
       if (type.equals("110")) {
         String[] sessions = message.split("\n");
         String lastSessionMessage = sessions[sessions.length - 1];
         String[] sessionData = lastSessionMessage.split("\\|");
         if (sessionData.length > 1) {
-          sessionIds.clear();
           String[] sessionIdsArray = sessionData[1].split(",");
-          sessionIds.addAll(Set.of(sessionIdsArray));
+          System.out.println("Incoming session IDs: " + Arrays.toString(sessionIdsArray));
+
+          // 기존 sessionIds에 새롭게 들어온 사용자 추가
+          Set<String> newSessionIds = Set.of(sessionIdsArray);
+          sessionIds.addAll(newSessionIds);
         }
       }
       else if (type.equals("111")) { // 사용자 퇴장
         String[] data = tokens[1].split(",");
+        System.out.println(data[0]);
         sessionIds.remove(data[0]);
       } else if (type.equals("113")) { // 게임 시작
         stateManager.switchTo("Map");
@@ -64,7 +67,4 @@ public class InnerWaitingRoomComponent extends JPanel {
       SwingUtilities.invokeLater(() -> listPanel.updateSessionList(sessionIds));
     }
   }
-
 }
-
-

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -1,18 +1,21 @@
 package org.kunp.inner;
 
+import org.kunp.ScreenManager;
 import org.kunp.ServerCommunicator;
 import org.kunp.StateManager;
+import org.kunp.map.Map;
+import org.kunp.map.Player;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.Arrays;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Set;
 
 
 public class InnerWaitingRoomComponent extends JPanel {
-  public InnerWaitingRoomComponent(StateManager stateManager, ServerCommunicator serverCommunicator, String roomName) {
-    System.out.println("move inner");
+  public InnerWaitingRoomComponent(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, String roomName, BufferedReader in, PrintWriter out) {
     setLayout(new BorderLayout());
     setBorder(BorderFactory.createLineBorder(Color.GRAY));
     setPreferredSize(new Dimension(350, 200));
@@ -25,19 +28,20 @@ public class InnerWaitingRoomComponent extends JPanel {
     InnerWaitingRoomListPanel listPanel = new InnerWaitingRoomListPanel(sessionIds);
     add(listPanel, BorderLayout.CENTER);
 
-    InnerWaitingRoomControlPanel controlPanel = new InnerWaitingRoomControlPanel(stateManager, roomName);
+    InnerWaitingRoomControlPanel controlPanel = new InnerWaitingRoomControlPanel(stateManager, screenManager, serverCommunicator, roomName, in, out);
     add(controlPanel, BorderLayout.SOUTH);
 
     // 메시지 리스너 등록
     ServerCommunicator.ServerMessageListener listener = message -> {
-      handleServerMessage(stateManager, message, sessionIds, listPanel);
+      handleServerMessage( message, sessionIds, listPanel);
     };
 
     stateManager.addMessageListener(listener);
   }
 
-  private void handleServerMessage(StateManager stateManager, String message, Set<String> sessionIds, InnerWaitingRoomListPanel listPanel) {
+  private void handleServerMessage(String message, Set<String> sessionIds, InnerWaitingRoomListPanel listPanel) {
     String[] tokens = message.split("\\|");
+    System.out.println(message);
 
     if (tokens.length > 1) {
       String type = tokens[0];
@@ -47,22 +51,16 @@ public class InnerWaitingRoomComponent extends JPanel {
         String[] sessionData = lastSessionMessage.split("\\|");
         if (sessionData.length > 1) {
           String[] sessionIdsArray = sessionData[1].split(",");
-          System.out.println("Incoming session IDs: " + Arrays.toString(sessionIdsArray));
-
           Set<String> newSessionIds = Set.of(sessionIdsArray);
           sessionIds.addAll(newSessionIds);
         }
       }
       else if (type.equals("111")) { // 사용자 퇴장
         String[] data = tokens[1].split(",");
-        System.out.println(data[0]);
         sessionIds.remove(data[0]);
-      } else if (type.equals("113")) { // 게임 시작
-        stateManager.switchTo("Map");
       } else {
         System.out.println("Unhandled message type: " + type);
       }
-
       SwingUtilities.invokeLater(() -> listPanel.updateSessionList(sessionIds));
     }
   }

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -49,7 +49,6 @@ public class InnerWaitingRoomComponent extends JPanel {
           String[] sessionIdsArray = sessionData[1].split(",");
           System.out.println("Incoming session IDs: " + Arrays.toString(sessionIdsArray));
 
-          // 기존 sessionIds에 새롭게 들어온 사용자 추가
           Set<String> newSessionIds = Set.of(sessionIdsArray);
           sessionIds.addAll(newSessionIds);
         }

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -33,13 +33,13 @@ public class InnerWaitingRoomComponent extends JPanel {
 
     // 메시지 리스너 등록
     ServerCommunicator.ServerMessageListener listener = message -> {
-      handleServerMessage( message, sessionIds, listPanel);
+      handleServerMessage( message, sessionIds, listPanel, in, out, stateManager, screenManager);
     };
 
     stateManager.addMessageListener(listener);
   }
 
-  private void handleServerMessage(String message, Set<String> sessionIds, InnerWaitingRoomListPanel listPanel) {
+  private void handleServerMessage(String message, Set<String> sessionIds, InnerWaitingRoomListPanel listPanel, BufferedReader in, PrintWriter out, StateManager stateManager, ScreenManager screenManager) {
     String[] tokens = message.split("\\|");
     System.out.println(message);
 
@@ -58,6 +58,20 @@ public class InnerWaitingRoomComponent extends JPanel {
       else if (type.equals("111")) { // 사용자 퇴장
         String[] data = tokens[1].split(",");
         sessionIds.remove(data[0]);
+      }else if (type.equals("113")) {
+        SwingUtilities.invokeLater(() -> {
+          System.out.println("Game starting...");
+          try {
+            String role = tokens[1].equals("0") ? "tagger" : "normal";
+            Player player = new Player(
+                    Integer.parseInt(tokens[2]), Integer.parseInt(tokens[3]), role, out, stateManager.getSessionId()
+            );
+            screenManager.addScreen("Map", new Map(in, out, player, stateManager.getSessionId()));
+            System.out.println("Map screen added successfully."); // 화면 추가 확인
+          } catch (Exception ex) {
+            ex.printStackTrace(); // 오류 출력
+          }
+        });
       } else {
         System.out.println("Unhandled message type: " + type);
       }

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 public class InnerWaitingRoomComponent extends JPanel {
   public InnerWaitingRoomComponent(StateManager stateManager, ServerCommunicator serverCommunicator, String roomName) {
+    System.out.println("move inner");
     setLayout(new BorderLayout());
     setBorder(BorderFactory.createLineBorder(Color.GRAY));
     setPreferredSize(new Dimension(350, 200));
@@ -28,45 +29,42 @@ public class InnerWaitingRoomComponent extends JPanel {
 
     // 메시지 리스너 등록
     ServerCommunicator.ServerMessageListener listener = message -> {
-      if (stateManager.getCurrentScreen().equals("InnerWaitingRoom")) {
-        handleServerMessage(stateManager, message, sessionIds, listPanel);
-      }
+      System.out.println("inner message");
+      handleServerMessage(stateManager, message, sessionIds, listPanel);
     };
 
     stateManager.addMessageListener(listener);
-
-    // 컴포넌트가 비활성화될 때 리스너 제거
-    addComponentListener(new java.awt.event.ComponentAdapter() {
-      @Override
-      public void componentHidden(java.awt.event.ComponentEvent e) {
-        stateManager.removeMessageListener(listener);
-      }
-    });
   }
 
   private void handleServerMessage(StateManager stateManager, String message, Set<String> sessionIds, InnerWaitingRoomListPanel listPanel) {
     String[] tokens = message.split("\\|");
+
     if (tokens.length > 1) {
       String type = tokens[0];
-      String[] data = tokens[1].split(",");
-
-      switch (type) {
-        case "110": // 새 사용자 입장
-          sessionIds.addAll(Set.of(data));
-          break;
-        case "111": // 사용자 퇴장
-          sessionIds.remove(data[0]);
-          break;
-        case "113": // 게임 시작
-          stateManager.switchTo("Map");
-          break;
-        default:
-          System.out.println("Unhandled message type: " + type);
+      System.out.println(type);
+      if (type.equals("110")) {
+        String[] sessions = message.split("\n");
+        String lastSessionMessage = sessions[sessions.length - 1];
+        String[] sessionData = lastSessionMessage.split("\\|");
+        if (sessionData.length > 1) {
+          sessionIds.clear();
+          String[] sessionIdsArray = sessionData[1].split(",");
+          sessionIds.addAll(Set.of(sessionIdsArray));
+        }
+      }
+      else if (type.equals("111")) { // 사용자 퇴장
+        String[] data = tokens[1].split(",");
+        sessionIds.remove(data[0]);
+      } else if (type.equals("113")) { // 게임 시작
+        stateManager.switchTo("Map");
+      } else {
+        System.out.println("Unhandled message type: " + type);
       }
 
       SwingUtilities.invokeLater(() -> listPanel.updateSessionList(sessionIds));
     }
   }
+
 }
 
 

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomControlPanel.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomControlPanel.java
@@ -1,18 +1,13 @@
 package org.kunp.inner;
 
-import org.kunp.map.Map;
-import org.kunp.map.Player;
-import org.kunp.waiting.WaitingRoomCreationPanel;
-import org.kunp.waiting.WaitingRoomListPanel;
+import org.kunp.StateManager;
 
 import javax.swing.*;
 import java.awt.*;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.PrintWriter;
 
 public class InnerWaitingRoomControlPanel extends JPanel {
-    public InnerWaitingRoomControlPanel(JPanel parentPanel, String roomName, BufferedReader in, PrintWriter out, String sessionId) {
+
+    public InnerWaitingRoomControlPanel(StateManager stateManager, String roomName) {
         setLayout(new FlowLayout(FlowLayout.RIGHT, 5, 5));
         setPreferredSize(new Dimension(350, 50));
 
@@ -26,56 +21,20 @@ public class InnerWaitingRoomControlPanel extends JPanel {
         exitButton.setPreferredSize(new Dimension(100, 30));
         add(exitButton);
 
+        // 게임 시작 버튼
         startGameButton.addActionListener(e -> {
-            new Thread(() -> {
-                try {
-                    String message = String.format("105|%s|%s|%d|%d|1", sessionId, roomName, 0, 0);
-                    out.println(message);
-                    out.flush();
-                    String response = in.readLine();
-                    System.out.println(response);
-
-                    String[] tokens = response.split("\\|");
-                    String role;
-                    if(Integer.parseInt(tokens[2]) == 0){
-                        role = "tagger";
-                    }else{
-                        role = "normal";
-                    }
-                    Player player = new Player(Integer.parseInt(tokens[3]), Integer.parseInt(tokens[4]), role, out, sessionId);
-                    SwingUtilities.invokeLater(() -> {
-                        parentPanel.removeAll();
-                        parentPanel.add(new Map(in, out, player, sessionId));
-                        parentPanel.revalidate();
-                        parentPanel.repaint();
-                    });
-                } catch (IOException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }).start();
+            String message = String.format("105|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, 0, 0);
+            stateManager.sendServerRequest(message, () -> {
+                JOptionPane.showMessageDialog(this, "게임이 곧 시작됩니다.");
+            });
         });
 
+        // 나가기 버튼
         exitButton.addActionListener(e -> {
-            new Thread(()->{
-                String message = String.format("103|%s|%s|%d|%d|1", sessionId, roomName, 0, 0);
-                out.println(message);
-                out.flush();
-
-                SwingUtilities.invokeLater(() -> {
-                    parentPanel.removeAll(); // 기존 컴포넌트 제거
-
-                    // 패널 레이아웃 명확히 설정 (BorderLayout으로 유지)
-                    parentPanel.setLayout(new BorderLayout());
-
-                    // 대기실 목록 및 생성 패널 추가
-                    parentPanel.add(new WaitingRoomListPanel(parentPanel, in, out, sessionId), BorderLayout.CENTER);
-                    parentPanel.add(new WaitingRoomCreationPanel(parentPanel, in, out, sessionId), BorderLayout.SOUTH);
-
-                    // UI 갱신
-                    parentPanel.revalidate();
-                    parentPanel.repaint();
-                });
-            }).start();
+            String message = String.format("103|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, 0, 0);
+            stateManager.sendServerRequest(message, () -> {
+                stateManager.switchTo("WaitingRoom");
+            });
         });
     }
 }

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomControlPanel.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomControlPanel.java
@@ -1,13 +1,19 @@
 package org.kunp.inner;
 
+import org.kunp.ScreenManager;
+import org.kunp.ServerCommunicator;
 import org.kunp.StateManager;
+import org.kunp.map.Map;
+import org.kunp.map.Player;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
 
 public class InnerWaitingRoomControlPanel extends JPanel {
 
-    public InnerWaitingRoomControlPanel(StateManager stateManager, String roomName) {
+    public InnerWaitingRoomControlPanel(StateManager stateManager, ScreenManager screenManager,ServerCommunicator serverCommunicator, String roomName, BufferedReader in, PrintWriter out) {
         setLayout(new FlowLayout(FlowLayout.RIGHT, 5, 5));
         setPreferredSize(new Dimension(350, 50));
 
@@ -21,12 +27,24 @@ public class InnerWaitingRoomControlPanel extends JPanel {
         exitButton.setPreferredSize(new Dimension(100, 30));
         add(exitButton);
 
+        serverCommunicator.addMessageListener(message -> {
+            String[] tokens = message.split("\\|");
+            if (tokens[0].equals("113")){
+                SwingUtilities.invokeLater(() -> {
+                    System.out.println("Game starting...");
+                    String role = tokens[1].equals("0") ? "tagger" : "normal";
+                    Player player = new Player(
+                            Integer.parseInt(tokens[2]), Integer.parseInt(tokens[3]), role, out, stateManager.getSessionId()
+                    );
+                    screenManager.addScreen("Map", new Map(in, out, player, stateManager.getSessionId()));
+                });
+            }
+        });
+
         // 게임 시작 버튼
         startGameButton.addActionListener(e -> {
             String message = String.format("105|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, 0, 0);
-            stateManager.sendServerRequest(message, () -> {
-                JOptionPane.showMessageDialog(this, "게임이 곧 시작됩니다.");
-            });
+            serverCommunicator.sendRequest(message);
         });
 
         // 나가기 버튼

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomControlPanel.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomControlPanel.java
@@ -27,20 +27,6 @@ public class InnerWaitingRoomControlPanel extends JPanel {
         exitButton.setPreferredSize(new Dimension(100, 30));
         add(exitButton);
 
-        serverCommunicator.addMessageListener(message -> {
-            String[] tokens = message.split("\\|");
-            if (tokens[0].equals("113")){
-                SwingUtilities.invokeLater(() -> {
-                    System.out.println("Game starting...");
-                    String role = tokens[1].equals("0") ? "tagger" : "normal";
-                    Player player = new Player(
-                            Integer.parseInt(tokens[2]), Integer.parseInt(tokens[3]), role, out, stateManager.getSessionId()
-                    );
-                    screenManager.addScreen("Map", new Map(in, out, player, stateManager.getSessionId()));
-                });
-            }
-        });
-
         // 게임 시작 버튼
         startGameButton.addActionListener(e -> {
             String message = String.format("105|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, 0, 0);

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomListPanel.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomListPanel.java
@@ -22,10 +22,6 @@ public class InnerWaitingRoomListPanel extends JPanel {
     public void updateSessionList(Set<String> sessionIds) {
         gridPanel.removeAll();
 
-        if (sessionIds.size() % 2 != 0) {
-            sessionIds.add("대기 중"); // 임시 자리
-        }
-
         for (String id : sessionIds) {
             JPanel userPanel = new JPanel();
             userPanel.setBorder(BorderFactory.createLineBorder(Color.BLACK));

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomListPanel.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomListPanel.java
@@ -5,7 +5,7 @@ import java.awt.*;
 import java.util.Set;
 
 public class InnerWaitingRoomListPanel extends JPanel {
-    private JPanel gridPanel;
+    private final JPanel gridPanel;
 
     public InnerWaitingRoomListPanel(Set<String> sessionIds) {
         setLayout(new BorderLayout());
@@ -20,23 +20,22 @@ public class InnerWaitingRoomListPanel extends JPanel {
     }
 
     public void updateSessionList(Set<String> sessionIds) {
-        gridPanel.removeAll(); // 기존 컴포넌트 제거
+        gridPanel.removeAll();
 
-        // 짝수 인원만 추가
         if (sessionIds.size() % 2 != 0) {
-            sessionIds.add("대기 중"); // 임시로 빈 자리 추가
+            sessionIds.add("대기 중"); // 임시 자리
         }
 
         for (String id : sessionIds) {
             JPanel userPanel = new JPanel();
             userPanel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
-            userPanel.setLayout(new GridBagLayout()); // 중앙 정렬을 위해 GridBagLayout 사용
+            userPanel.setLayout(new GridBagLayout());
 
             JLabel label = new JLabel(id);
-            label.setFont(new Font("Arial", Font.BOLD, 16)); // 글꼴 설정 (크기 및 스타일)
-            label.setHorizontalAlignment(SwingConstants.CENTER); // 중앙 정렬
+            label.setFont(new Font("Arial", Font.BOLD, 16));
+            label.setHorizontalAlignment(SwingConstants.CENTER);
 
-            userPanel.add(label); // 패널에 라벨 추가
+            userPanel.add(label);
             gridPanel.add(userPanel);
         }
 

--- a/client/src/main/java/org/kunp/waiting/WaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/waiting/WaitingRoomComponent.java
@@ -1,17 +1,16 @@
 package org.kunp.waiting;
 
+import org.kunp.ScreenManager;
+import org.kunp.ServerCommunicator;
+import org.kunp.StateManager;
 import org.kunp.inner.InnerWaitingRoomComponent;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.BufferedReader;
-import java.io.PrintWriter;
 
-// 대기실 컴포넌트
+
 public class WaitingRoomComponent extends JPanel {
-    public WaitingRoomComponent(BufferedReader in, PrintWriter out, String sessionId, String roomName, JPanel parentPanel) {
+    public WaitingRoomComponent(String sessionId, String roomName, StateManager stateManager, ScreenManager screenManager, ServerCommunicator serverCommunicator) {
         setLayout(new BorderLayout());
         setBorder(BorderFactory.createLineBorder(Color.GRAY));
         setPreferredSize(new Dimension(350, 70));
@@ -20,7 +19,6 @@ public class WaitingRoomComponent extends JPanel {
         nameLabel.setHorizontalAlignment(SwingConstants.LEFT);
         add(nameLabel, BorderLayout.CENTER);
 
-        // 입장 버튼을 오른쪽 아래에 작게 배치
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 5, 5));
         JButton enterButton = new JButton("입장");
         enterButton.setFocusPainted(false);
@@ -29,19 +27,13 @@ public class WaitingRoomComponent extends JPanel {
 
         add(buttonPanel, BorderLayout.SOUTH);
 
-        enterButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                String message = String.format("101|%s|%s|%d|%d|1", sessionId, roomName, 0, 0);
-                out.println(message);
-                out.flush();
-
-                // GameRoomComponent로 전환
-                parentPanel.removeAll();
-                parentPanel.add(new InnerWaitingRoomComponent(parentPanel, roomName, in, out, sessionId));
-                parentPanel.revalidate();
-                parentPanel.repaint();
-            }
+        enterButton.addActionListener(e -> {
+            String message = String.format("101|%s|%s|%d|%d|1", sessionId, roomName, 0, 0);
+            // InnerWaitingRoom 화면 (추가된 컴포넌트)
+            screenManager.addScreen("InnerWaitingRoom", new InnerWaitingRoomComponent(stateManager, serverCommunicator, roomName));
+            stateManager.sendServerRequest(message, () -> {
+                stateManager.switchTo("InnerWaitingRoom");
+            });
         });
     }
 }

--- a/client/src/main/java/org/kunp/waiting/WaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/waiting/WaitingRoomComponent.java
@@ -7,10 +7,12 @@ import org.kunp.inner.InnerWaitingRoomComponent;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
 
 
 public class WaitingRoomComponent extends JPanel {
-    public WaitingRoomComponent(String sessionId, String roomName, StateManager stateManager, ScreenManager screenManager, ServerCommunicator serverCommunicator) {
+    public WaitingRoomComponent(String sessionId, String roomName, StateManager stateManager, ScreenManager screenManager, ServerCommunicator serverCommunicator, BufferedReader in, PrintWriter out) {
         setLayout(new BorderLayout());
         setBorder(BorderFactory.createLineBorder(Color.GRAY));
         setPreferredSize(new Dimension(350, 70));
@@ -30,7 +32,7 @@ public class WaitingRoomComponent extends JPanel {
         enterButton.addActionListener(e -> {
             String message = String.format("101|%s|%s|%d|%d|1", sessionId, roomName, 0, 0);
             // InnerWaitingRoom 화면 (추가된 컴포넌트)
-            screenManager.addScreen("InnerWaitingRoom", new InnerWaitingRoomComponent(stateManager, serverCommunicator, roomName));
+            screenManager.addScreen("InnerWaitingRoom", new InnerWaitingRoomComponent(stateManager, serverCommunicator, screenManager, roomName, in, out));
             stateManager.sendServerRequest(message, () -> {
                 stateManager.switchTo("InnerWaitingRoom");
             });

--- a/client/src/main/java/org/kunp/waiting/WaitingRoomCreationPanel.java
+++ b/client/src/main/java/org/kunp/waiting/WaitingRoomCreationPanel.java
@@ -6,13 +6,15 @@ import org.kunp.StateManager;
 import org.kunp.inner.InnerWaitingRoomComponent;
 import javax.swing.*;
 import java.awt.*;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
 
 public class WaitingRoomCreationPanel extends JPanel {
     private final JTextField roomNameField;
     private final JTextField timeLimitField;
     private final JTextField playerLimitField;
 
-    public WaitingRoomCreationPanel(StateManager stateManager, ScreenManager screenManager, ServerCommunicator serverCommunicator) {
+    public WaitingRoomCreationPanel(StateManager stateManager, ScreenManager screenManager, ServerCommunicator serverCommunicator, BufferedReader in, PrintWriter out) {
         setLayout(new BorderLayout());
         setPreferredSize(new Dimension(350, 150));
 
@@ -75,7 +77,7 @@ public class WaitingRoomCreationPanel extends JPanel {
                         stateManager.sendServerRequest(message, () -> {});
 
                         message = String.format("101|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, timeLimit, playerLimit);
-                        screenManager.addScreen("InnerWaitingRoom", new InnerWaitingRoomComponent(stateManager, serverCommunicator, roomName));
+                        screenManager.addScreen("InnerWaitingRoom", new InnerWaitingRoomComponent(stateManager, serverCommunicator, screenManager, roomName, in ,out));
                         stateManager.sendServerRequest(message, () -> {
                             stateManager.switchTo("InnerWaitingRoom");
                         });

--- a/client/src/main/java/org/kunp/waiting/WaitingRoomCreationPanel.java
+++ b/client/src/main/java/org/kunp/waiting/WaitingRoomCreationPanel.java
@@ -1,5 +1,7 @@
 package org.kunp.waiting;
 
+import org.kunp.ScreenManager;
+import org.kunp.ServerCommunicator;
 import org.kunp.StateManager;
 import org.kunp.inner.InnerWaitingRoomComponent;
 import javax.swing.*;
@@ -10,7 +12,7 @@ public class WaitingRoomCreationPanel extends JPanel {
     private final JTextField timeLimitField;
     private final JTextField playerLimitField;
 
-    public WaitingRoomCreationPanel(StateManager stateManager) {
+    public WaitingRoomCreationPanel(StateManager stateManager, ScreenManager screenManager, ServerCommunicator serverCommunicator) {
         setLayout(new BorderLayout());
         setPreferredSize(new Dimension(350, 150));
 
@@ -70,6 +72,10 @@ public class WaitingRoomCreationPanel extends JPanel {
                         JOptionPane.showMessageDialog(this, "입력 오류: 제한 시간과 인원을 확인하세요.", "입력 오류", JOptionPane.WARNING_MESSAGE);
                     } else {
                         String message = String.format("102|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, timeLimit, playerLimit);
+                        stateManager.sendServerRequest(message, () -> {});
+
+                        message = String.format("101|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, timeLimit, playerLimit);
+                        screenManager.addScreen("InnerWaitingRoom", new InnerWaitingRoomComponent(stateManager, serverCommunicator, roomName));
                         stateManager.sendServerRequest(message, () -> {
                             stateManager.switchTo("InnerWaitingRoom");
                         });

--- a/client/src/main/java/org/kunp/waiting/WaitingRoomListPanel.java
+++ b/client/src/main/java/org/kunp/waiting/WaitingRoomListPanel.java
@@ -13,7 +13,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class WaitingRoomListPanel extends JPanel {
+    ServerCommunicator serverCommunicator;
     public WaitingRoomListPanel(String sessionId, StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, BufferedReader in, PrintWriter out) {
+        this.serverCommunicator = serverCommunicator;
         setLayout(new BorderLayout());
         setBorder(new TitledBorder("대기실 목록"));
 
@@ -35,18 +37,18 @@ public class WaitingRoomListPanel extends JPanel {
         serverCommunicator.addMessageListener(message -> {
             String[] roomData = message.split("\\|");
             SwingUtilities.invokeLater(() -> {
-                rooms.clear();
-                roomListPanel.removeAll();
-                if(roomData[0].equals("112")){
-                    if(roomData.length > 1) {
+                if(roomData[0].equals("112")) {
+                    rooms.clear();
+                    roomListPanel.removeAll();
+                    if (roomData.length > 1) {
                         Arrays.stream(roomData[1].split(","))
                                 .map(el -> new WaitingRoomComponent(sessionId, el, stateManager, screenManager, serverCommunicator, in, out))
                                 .forEach(rooms::add);
                     }
+                    rooms.forEach(roomListPanel::add);
+                    roomListPanel.revalidate();
+                    roomListPanel.repaint();
                 }
-                rooms.forEach(roomListPanel::add);
-                roomListPanel.revalidate();
-                roomListPanel.repaint();
             });
         });
 

--- a/client/src/main/java/org/kunp/waiting/WaitingRoomListPanel.java
+++ b/client/src/main/java/org/kunp/waiting/WaitingRoomListPanel.java
@@ -1,85 +1,58 @@
 package org.kunp.waiting;
 
+import org.kunp.ScreenManager;
+import org.kunp.ServerCommunicator;
+import org.kunp.StateManager;
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
-// 대기실 목록 리스트 패널
 public class WaitingRoomListPanel extends JPanel {
-    public WaitingRoomListPanel(
-            JPanel parentPanel, BufferedReader in, PrintWriter out, String sessionId) {
-
+    public WaitingRoomListPanel(String sessionId, StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager) {
         setLayout(new BorderLayout());
         setBorder(new TitledBorder("대기실 목록"));
 
-        // 대기실 목록은 스크롤이 가능한 리스트
         JPanel roomListPanel = new JPanel();
         roomListPanel.setLayout(new BoxLayout(roomListPanel, BoxLayout.Y_AXIS));
 
         JScrollPane scrollPane = new JScrollPane(roomListPanel);
         scrollPane.setPreferredSize(new Dimension(400, 250));
-
-        // 마우스 휠 스크롤시 속도 설정
         scrollPane.getVerticalScrollBar().setUnitIncrement(16);
 
         List<WaitingRoomComponent> rooms = new ArrayList<>();
-
         JButton refreshButton = new JButton("새로고침");
         refreshButton.setFocusPainted(false);
         refreshButton.setPreferredSize(new Dimension(100, 50));
 
         add(refreshButton, BorderLayout.NORTH);
         add(scrollPane, BorderLayout.CENTER);
+
+        serverCommunicator.addMessageListener(message -> {
+            String[] roomData = message.split("\\|");
+            SwingUtilities.invokeLater(() -> {
+                rooms.clear();
+                roomListPanel.removeAll();
+                if(roomData[0].equals("112")){
+                    if(roomData.length > 1) {
+                        Arrays.stream(roomData[1].split(","))
+                                .map(el -> new WaitingRoomComponent(sessionId, el, stateManager, screenManager, serverCommunicator))
+                                .forEach(rooms::add);
+                    }
+                }
+                rooms.forEach(roomListPanel::add);
+                roomListPanel.revalidate();
+                roomListPanel.repaint();
+            });
+        });
+
         refreshButton.addActionListener(e -> {
-            new Thread(() -> {
-                try {
-                    String message = String.format("100|%s|%s|%d|%d|1", sessionId, null, 0, 0);
-                    out.println(message);
-                    out.flush();
-                    String response = in.readLine();
-                    String[] tokens = response.split("\\|");
-
-                    SwingUtilities.invokeLater(() -> {
-                        try {
-                            System.out.println("Running on EDT: " + SwingUtilities.isEventDispatchThread());
-
-                            // Rooms 업데이트
-                            rooms.clear();
-                            if(tokens.length > 1) {
-                                Arrays.stream(tokens[1].split(","))
-                                        .map(el -> new WaitingRoomComponent(in, out, sessionId, el, parentPanel))
-                                        .forEach(rooms::add);
-                            }
-
-                            // RoomListPanel 업데이트
-                            roomListPanel.removeAll();
-                            rooms.forEach(roomListPanel::add);
-
-                            // 디버깅 로그
-                            System.out.println("Number of rooms: " + rooms.size());
-                            System.out.println("Room list panel component count: " + roomListPanel.getComponentCount());
-
-                            // 갱신
-                            roomListPanel.revalidate();
-                            roomListPanel.repaint();
-
-                            // 상위 패널 갱신
-                            parentPanel.revalidate();
-                            parentPanel.repaint();
-                        } catch (Exception exx) {
-                            exx.printStackTrace();
-                        }
-                    });
-
-                } catch (IOException ex) {
-                    ex.printStackTrace(); // 예외 로그
-                } // 스레드 시작
-            }).start();
+            // 방 목록 요청
+            String requestMessage = String.format("100|%s|%s|%d|%d|1", sessionId, null, 0, 0); // 요청 메시지 형식
+            serverCommunicator.sendRequest(requestMessage);
         });
     }
 }
+

--- a/client/src/main/java/org/kunp/waiting/WaitingRoomListPanel.java
+++ b/client/src/main/java/org/kunp/waiting/WaitingRoomListPanel.java
@@ -6,12 +6,14 @@ import org.kunp.StateManager;
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class WaitingRoomListPanel extends JPanel {
-    public WaitingRoomListPanel(String sessionId, StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager) {
+    public WaitingRoomListPanel(String sessionId, StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, BufferedReader in, PrintWriter out) {
         setLayout(new BorderLayout());
         setBorder(new TitledBorder("대기실 목록"));
 
@@ -38,7 +40,7 @@ public class WaitingRoomListPanel extends JPanel {
                 if(roomData[0].equals("112")){
                     if(roomData.length > 1) {
                         Arrays.stream(roomData[1].split(","))
-                                .map(el -> new WaitingRoomComponent(sessionId, el, stateManager, screenManager, serverCommunicator))
+                                .map(el -> new WaitingRoomComponent(sessionId, el, stateManager, screenManager, serverCommunicator, in, out))
                                 .forEach(rooms::add);
                     }
                 }


### PR DESCRIPTION
## 🐣Title
[Fix/client/waitingroom-UI] 대기실 오류 및 게임 시작 수정

---

<br/>

## 🐣Part
client

---

<br/>

## 🐣Key Changes
1. 대기실 입퇴장 오류 수정
2. 새로고침 오류 수정
3. 게임 룸 입장 수정

---

<br/>

## 🐣Simulation

https://github.com/user-attachments/assets/0b32a510-6cf4-4371-b1f5-2526e6550e72


---

<br/>

## 🐣To Reviewer
1. 클라이언트 스레드 자체가 실행 중일 때는 유효하게 작동합니다
2. 사용자가 스윙 윈도우 창 자체를 종료했을 때의 예외처리를 게임 전체적으로 해야할 것 같습니다. @solved2 
3. 게임 룸으로 이동할 때 레이아웃이 바뀌는 것 같아서 맵이랑 맞춰야 할 것 같습니다.
4. 게임 시작 시 도망자의 경우 플레이어가 그려지지 않는 오류가 있습니다. 게임 맵에서 도망자 그림이 설정되지 않은 것 같아요!..

---

<br/>

## 🐣Next
게임 결과 화면 출력

---

 <br/>

## 🐣Issue

---


<br/>