### PR TITLE
[Fix/client/map]

### DIFF
--- a/client/src/main/java/org/kunp/Client.java
+++ b/client/src/main/java/org/kunp/Client.java
@@ -1,6 +1,7 @@
 package org.kunp;
 
 import org.kunp.inner.InnerWaitingRoomComponent;
+import org.kunp.map.Constants;
 import org.kunp.waiting.WaitingRoomCreationPanel;
 import org.kunp.waiting.WaitingRoomListPanel;
 
@@ -41,8 +42,14 @@ public class Client {
         // 프레임 설정
         JFrame frame = new JFrame("Tag Game - 대기실");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.setSize(600, 500); // 화면 크기
+        frame.setPreferredSize(new Dimension(500, 500));
+        frame.setSize(500, 500); // 화면 크기
+        frame.pack();
         frame.setLayout(new BorderLayout());
+        Insets insets = frame.getInsets();
+        int width = 500 + insets.left + insets.right;
+        int height = 500 + insets.top + insets.bottom;
+        frame.setSize(width, height);
 
         // 화면 등록
         registerScreens(sessionId, screenManager, stateManager, serverCommunicator);

--- a/client/src/main/java/org/kunp/ServerCommunicator.java
+++ b/client/src/main/java/org/kunp/ServerCommunicator.java
@@ -24,7 +24,7 @@ public class ServerCommunicator {
             try {
                 String message;
                 while ((message = in.readLine()) != null) {
-                    System.out.println(message);
+                    //System.out.println(message);
                     notifyListeners(message);
                 }
             } catch (IOException e) {

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -67,26 +67,9 @@ public class InnerWaitingRoomComponent extends JPanel {
                     Player player = new Player(stateManager, serverCommunicator, screenManager,
                             Integer.parseInt(tokens[2]), Integer.parseInt(tokens[3]), role, out, stateManager.getSessionId()
                     );
-                    // Map 화면 생성 및 추가
-                    Map map = new Map(stateManager, serverCommunicator, screenManager, player, stateManager.getSessionId());
-                    screenManager.addScreen("Map", map);
+                    screenManager.addScreen("Map", new Map(stateManager, serverCommunicator, screenManager, player, stateManager.getSessionId()));
                     System.out.println("Map screen added successfully.");
                     stateManager.switchTo("Map");
-
-                    // 포커스를 강제로 요청
-                    SwingUtilities.invokeLater(() -> {
-                        if (!map.requestFocusInWindow()) {
-                            Timer focusRetryTimer = new Timer(100, e -> {
-                                if (map.requestFocusInWindow()) {
-                                    ((Timer) e.getSource()).stop(); // 성공하면 타이머 중지
-                                    System.out.println("Map focus successfully set.");
-                                } else {
-                                    System.out.println("Retrying focus on Map...");
-                                }
-                            });
-                            focusRetryTimer.start();
-                        }
-                    });
                 } catch (Exception ex) {
                     ex.printStackTrace(); // 오류 출력
                 }

--- a/client/src/main/java/org/kunp/map/Map.java
+++ b/client/src/main/java/org/kunp/map/Map.java
@@ -56,7 +56,6 @@ public class Map extends JPanel {
 
         moveTimer = new Timer(50, e -> checkKeyboardInput());
         moveTimer.start();
-        requestFocusInWindow();
 
         serverCommunicator.addMessageListener(message -> {
             String[] tokens = message.split("\\|");
@@ -70,6 +69,21 @@ public class Map extends JPanel {
                     else locations.get(mover_sessionId).setLocation(mapIdx, x, y);
                 }
                 repaint();
+            }
+        });
+
+        // 포커스 요청
+        SwingUtilities.invokeLater(() -> {
+            if (!requestFocusInWindow()) {
+                Timer focusRetryTimer = new Timer(100, evt -> {
+                    if (isFocusOwner() || requestFocusInWindow()) {
+                        ((Timer) evt.getSource()).stop(); // 성공하면 타이머 중지
+                        System.out.println("Focus successfully set on Map.");
+                    }
+                });
+                focusRetryTimer.start();
+            } else {
+                System.out.println("Focus successfully set on Map.");
             }
         });
     }

--- a/client/src/main/java/org/kunp/map/Map.java
+++ b/client/src/main/java/org/kunp/map/Map.java
@@ -1,10 +1,18 @@
 package org.kunp.map;
 
+import org.kunp.ScreenManager;
+import org.kunp.ServerCommunicator;
+import org.kunp.StateManager;
+import org.kunp.inner.InnerWaitingRoomListPanel;
+import org.kunp.waiting.WaitingRoomComponent;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.*;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Set;
 
 public class Map extends JPanel {
     private MapPanel[][] maps;
@@ -12,14 +20,10 @@ public class Map extends JPanel {
     private final Player player;
     private final boolean[] keysPressed = new boolean[256];
     private final Timer moveTimer;
-    private final BufferedReader in;
-    private final PrintWriter out;
     private final String sessionId;
     private final HashMap<String, Location> locations = new HashMap<>();
 
-    public Map(BufferedReader in, PrintWriter out, Player player, String sessionId) {
-        this.in = in;
-        this.out = out;
+    public Map(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, Player player, String sessionId) {
         this.player = player;
         this.sessionId = sessionId;
 
@@ -54,8 +58,20 @@ public class Map extends JPanel {
         moveTimer.start();
         requestFocusInWindow();
 
-        LocationSyncThread lst = new LocationSyncThread(in);
-        lst.start();
+        serverCommunicator.addMessageListener(message -> {
+            String[] tokens = message.split("\\|");
+            String type = tokens[0];
+            if(type.equals("210") || type.equals("211") || type.equals("212")){
+                String mover_sessionId = tokens[1];
+                int x = Integer.parseInt(tokens[2]), y = Integer.parseInt(tokens[3]);
+                int mapIdx = Integer.parseInt(tokens[4]);
+                synchronized (locations){
+                    if(!locations.containsKey(mover_sessionId)) locations.put(mover_sessionId, new Location(mapIdx, x, y));
+                    else locations.get(mover_sessionId).setLocation(mapIdx, x, y);
+                }
+                repaint();
+            }
+        });
     }
 
     private void initializeMapPanels() {
@@ -83,6 +99,7 @@ public class Map extends JPanel {
     }
 
     private void movePlayer(int keyCode) {
+        System.out.println("key identified");
         int newX = player.getX(), newY = player.getY();
         int xx = 0, yy = 0;
         switch (keyCode) {
@@ -132,35 +149,5 @@ public class Map extends JPanel {
         add(maps[currentMapX][currentMapY], BorderLayout.CENTER);
         revalidate();
         requestFocusInWindow();
-    }
-
-    private class LocationSyncThread extends Thread{
-        private BufferedReader in = null;
-        public LocationSyncThread(BufferedReader in){
-            this.in = in;
-        }
-        public void run(){
-            try {
-                String line = null;
-                while ((line = in.readLine()) != null) {
-                    System.out.println(line);
-                    String[] parts = line.split("\\|");
-                    String sessionId = parts[1];
-                    int x = Integer.parseInt(parts[2]);
-                    int y = Integer.parseInt(parts[3]);
-                    int roomNumber = Integer.parseInt(parts[4]);
-                    synchronized (locations){
-                        if(!locations.containsKey(sessionId)) locations.put(sessionId, new Location(roomNumber, x, y));
-                        else locations.get(sessionId).setLocation(roomNumber, x, y);
-                    }
-                    repaint();
-                }
-            }catch(Exception ex){
-            }finally{
-                try{
-                    if(in != null) in.close();
-                }catch(Exception ex){}
-            }
-        }
     }
 }

--- a/client/src/main/java/org/kunp/map/MapPanel.java
+++ b/client/src/main/java/org/kunp/map/MapPanel.java
@@ -28,7 +28,7 @@ public class MapPanel extends JPanel {
         List<Integer> numbers = new ArrayList<>();
         for (int i = 20; i <= 470; i += 10) numbers.add(i);
 
-        Random random = new Random();
+        Random random = new Random(3*mapX+mapY);
         List<int[]> locs = new ArrayList<>();
         while (locs.size() < Constants.NUM_ROCKS) {
             int x = numbers.get(random.nextInt(numbers.size()));

--- a/client/src/main/java/org/kunp/map/Player.java
+++ b/client/src/main/java/org/kunp/map/Player.java
@@ -1,5 +1,9 @@
 package org.kunp.map;
 
+import org.kunp.ScreenManager;
+import org.kunp.ServerCommunicator;
+import org.kunp.StateManager;
+
 import java.io.PrintWriter;
 
 public class Player {
@@ -8,14 +12,16 @@ public class Player {
     private String sessionId;
     private int mapIdx;
     private PrintWriter out;
+    private ServerCommunicator serverCommunicator;
 
-    public Player(int startX, int startY, String role, PrintWriter out, String sessionId) {
+    public Player(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, int startX, int startY, String role, PrintWriter out, String sessionId) {
         this.x = startX;
         this.y = startY;
         this.role = role;
         this.out = out;
         this.sessionId = sessionId;
         this.mapIdx = 5;
+        this.serverCommunicator = serverCommunicator;
     }
 
     public int getX() {
@@ -41,19 +47,16 @@ public class Player {
         x += dx;
         y += dy;
         sendLocation();
-        //System.out.println("("+x+","+y+")");
     }
 
     public void sendInteraction(){
-        String message = String.format("202|%s|%d|%d|%d|1", sessionId, x, y, mapIdx);
-        out.println(message);
-        out.flush();
+        String requestMessage = String.format("202|%s|%s|%d|%d|1", sessionId, x, y, mapIdx);
+        serverCommunicator.sendRequest(requestMessage);
     }
 
     private void sendLocation() {
-        String message = String.format("201|%s|%d|%d|%d|1", sessionId, x, y, mapIdx);
-        out.println(message);
-        out.flush();
+        String requestMessage = String.format("201|%s|%s|%d|%d|1", sessionId, x, y, mapIdx);
+        serverCommunicator.sendRequest(requestMessage);
     }
 }
 


### PR DESCRIPTION
## 🐣Title
[Fix/client/map]
---

<br/>

## 🐣Part
Client
---

<br/>

## 🐣Key Changes
* map에서 동작하는 positionSyncThread를 없애고, ServerCommunicator를 이용하도록 수정했습니다.
* 모든 클라이언트의 장애물 생성위치가 같도록 수정했습니다.
* 대기실 창 크기와 게임 창 크기를 통일시켰습니다.
---

<br/>

## 🐣Simulation

https://github.com/user-attachments/assets/7a320a50-0a91-4b79-9ba7-523508ee63ab


---

<br/>

## 🐣To Reviewer

---

<br/>

## 🐣Next

---

 <br/>

## 🐣Issue
1. 맵에서 클라이언트가 스윙 창을 꺼서 종료해도, 서버에서 해당 유저의 location을 계속 브로드캐스트하는 것 같습니다. 연결이 종료된 순간, "210|sessionID|-1|-1|..."이런식으로 x, y좌표를 특별하게 설정하여 브로드캐스트하여 다른 클라이언트들에게 이 클라이언트를 더 이상 표시하지 말도록 인지시켜야 할 것 같습니다.
2. 서버에서 클라이언트의 위치를 브로드캐스팅할 때, role도 추가로 보내줘야 할 것 같습니다 (role에 따라 그래픽을 다르게 표시해야 함)
3. 현재 Feat/Server/implement-interaction 브랜치에 있는 GameContext.java가 가장 최근에 업데이트된 코드로 알고있는데, 몇가지 오류가 발생합니다 (예: playerStates 객체가 없는데 사용중?).
---


<br/>