### PR TITLE
[feat/game-result-ui] 게임 결과 화면 ui 추가

### DIFF
--- a/client/src/main/java/org/kunp/Client.java
+++ b/client/src/main/java/org/kunp/Client.java
@@ -1,7 +1,6 @@
 package org.kunp;
 
-import org.kunp.inner.InnerWaitingRoomComponent;
-import org.kunp.map.Constants;
+import org.kunp.result.ResultComponent;
 import org.kunp.waiting.WaitingRoomCreationPanel;
 import org.kunp.waiting.WaitingRoomListPanel;
 

--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -67,7 +67,7 @@ public class InnerWaitingRoomComponent extends JPanel {
                     Player player = new Player(stateManager, serverCommunicator, screenManager,
                             Integer.parseInt(tokens[2]), Integer.parseInt(tokens[3]), role, out, stateManager.getSessionId()
                     );
-                    screenManager.addScreen("Map", new Map(stateManager, serverCommunicator, screenManager, player, stateManager.getSessionId()));
+                    screenManager.addScreen("Map", new Map(stateManager, serverCommunicator, screenManager, player, stateManager.getSessionId(), in, out));
                     System.out.println("Map screen added successfully.");
                     stateManager.switchTo("Map");
                 } catch (Exception ex) {

--- a/client/src/main/java/org/kunp/map/Map.java
+++ b/client/src/main/java/org/kunp/map/Map.java
@@ -3,16 +3,13 @@ package org.kunp.map;
 import org.kunp.ScreenManager;
 import org.kunp.ServerCommunicator;
 import org.kunp.StateManager;
-import org.kunp.inner.InnerWaitingRoomListPanel;
-import org.kunp.waiting.WaitingRoomComponent;
+import org.kunp.result.ResultComponent;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.*;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Set;
 
 public class Map extends JPanel {
     private MapPanel[][] maps;
@@ -23,7 +20,7 @@ public class Map extends JPanel {
     private final String sessionId;
     private final HashMap<String, Location> locations = new HashMap<>();
 
-    public Map(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, Player player, String sessionId) {
+    public Map(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, Player player, String sessionId, BufferedReader in, PrintWriter out) {
         this.player = player;
         this.sessionId = sessionId;
 
@@ -69,6 +66,13 @@ public class Map extends JPanel {
                     else locations.get(mover_sessionId).setLocation(mapIdx, x, y);
                 }
                 repaint();
+            }else if(type.equals("213")){
+                String gameId = tokens[1];
+                String result = Integer.parseInt(tokens[2]) == 1 ? "도망자 승리" : "술래 승리";
+                screenManager.addScreen("Result", new ResultComponent(stateManager, serverCommunicator, screenManager,result, gameId, in, out));
+                SwingUtilities.invokeLater(() -> {
+                    stateManager.switchTo("Result");
+                });
             }
         });
 

--- a/client/src/main/java/org/kunp/result/ResultComponent.java
+++ b/client/src/main/java/org/kunp/result/ResultComponent.java
@@ -1,0 +1,56 @@
+package org.kunp.result;
+
+import org.kunp.ScreenManager;
+import org.kunp.ServerCommunicator;
+import org.kunp.StateManager;
+import org.kunp.inner.InnerWaitingRoomComponent;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+
+public class ResultComponent extends JPanel {
+    public ResultComponent(StateManager stateManager, ServerCommunicator serverCommunicator, 
+                         ScreenManager screenManager, String gameResult, String roomName, BufferedReader in, PrintWriter out) {
+
+        setLayout(new BorderLayout());
+        setPreferredSize(new Dimension(500, 500));
+
+        // 결과 패널 생성
+        JPanel resultPanel = new JPanel();
+        resultPanel.setLayout(new BoxLayout(resultPanel, BoxLayout.Y_AXIS));
+        resultPanel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
+
+        // 게임 결과 레이블
+        JLabel resultLabel = new JLabel(gameResult);
+        resultLabel.setFont(new Font("Arial", Font.BOLD, 24));
+        resultLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        // 대기실 돌아가기 버튼
+        JButton returnButton = new JButton("대기실로 돌아가기");
+        returnButton.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        // 컴포넌트 배치
+        resultPanel.add(Box.createVerticalGlue());
+        resultPanel.add(resultLabel);
+        resultPanel.add(Box.createRigidArea(new Dimension(0, 20)));
+        resultPanel.add(returnButton);
+        resultPanel.add(Box.createVerticalGlue());
+        add(resultPanel, BorderLayout.CENTER);
+
+        returnButton.addActionListener(e -> {
+          String message = String.format("101|%s|%s|%d|%d|1", stateManager.getSessionId(), roomName, 0, 0);
+          String[] tokens = message.split("\\|");
+          if (tokens.length > 0) {
+            if (tokens[0].equals("110")) {
+                screenManager.addScreen("InnerWaitingRoom", new InnerWaitingRoomComponent(stateManager, serverCommunicator, screenManager, roomName, in, out));
+                stateManager.sendServerRequest(message, () -> {
+                    stateManager.switchTo("InnerWaitingRoom");
+                });
+              }
+            }
+          }
+        );
+    }
+}


### PR DESCRIPTION
## 🐣Title
[feat/game-result-ui] 게임 결과 화면 ui 추가

---

<br/>

## 🐣Part
Client

---

<br/>

## 🐣Key Changes
1. 게임 결과 ui 추가(ResultComponent)
2. Map ServerListener에 서버의 게임 종료 메세지 응답 받도록 수정

---

<br/>

## 🐣Simulation
![image](https://github.com/user-attachments/assets/03776891-374e-496b-88ad-83aab855b743)


---

<br/>

## 🐣To Reviewer
맵 수정사항 모두 완료되면 머지해서 다시 테스트해봐야할 것 같습니다!
우선 화면 ui와 버튼 클릭 시 innerwaitingcomponent로 돌아가도록 수정했습니다..!

---

<br/>

## 🐣Next

---

 <br/>

## 🐣Issue

---


<br/>