### PR TITLE
[Fix/client/map] 게임 중 나간 플레이어 맵에 표시X, 역할에 따른 플레이어 그래픽 그리기

### DIFF
--- a/client/src/main/java/org/kunp/map/Location.java
+++ b/client/src/main/java/org/kunp/map/Location.java
@@ -1,19 +1,22 @@
 package org.kunp.map;
 
 public class Location{
-    int roomNumber, x, y;
-    public Location(int roomNumber, int x, int y){
+    int roomNumber, x, y, role;
+    public Location(int role, int roomNumber, int x, int y){
+        this.role = role;
         this.roomNumber = roomNumber;
         this.x = x;
         this.y = y;
     }
 
-    public void setLocation(int roomNumber, int x, int y){
+    public void setLocation(int role, int roomNumber, int x, int y){
+        this.role = role;
         this.roomNumber = roomNumber;
         this.x = x;
         this.y = y;
     }
 
+    public int getRole() { return role; }
     public int getRoomNumber(){
         return roomNumber;
     }

--- a/client/src/main/java/org/kunp/map/Map.java
+++ b/client/src/main/java/org/kunp/map/Map.java
@@ -58,12 +58,14 @@ public class Map extends JPanel {
             String[] tokens = message.split("\\|");
             String type = tokens[0];
             if(type.equals("210") || type.equals("211") || type.equals("212")){
+                System.out.println(message);
                 String mover_sessionId = tokens[1];
                 int x = Integer.parseInt(tokens[2]), y = Integer.parseInt(tokens[3]);
                 int mapIdx = Integer.parseInt(tokens[4]);
+                int role = Integer.parseInt(tokens[6]);
                 synchronized (locations){
-                    if(!locations.containsKey(mover_sessionId)) locations.put(mover_sessionId, new Location(mapIdx, x, y));
-                    else locations.get(mover_sessionId).setLocation(mapIdx, x, y);
+                    if(!locations.containsKey(mover_sessionId)) locations.put(mover_sessionId, new Location(role, mapIdx, x, y));
+                    else locations.get(mover_sessionId).setLocation(role, mapIdx, x, y);
                 }
                 repaint();
             }else if(type.equals("213")){
@@ -73,6 +75,11 @@ public class Map extends JPanel {
                 SwingUtilities.invokeLater(() -> {
                     stateManager.switchTo("Result");
                 });
+            }else if(type.equals("214")){
+                String disconnectedSessionId = tokens[1];
+                synchronized (locations){
+                    locations.remove(disconnectedSessionId);
+                }
             }
         });
 
@@ -117,7 +124,6 @@ public class Map extends JPanel {
     }
 
     private void movePlayer(int keyCode) {
-        System.out.println("key identified");
         int newX = player.getX(), newY = player.getY();
         int xx = 0, yy = 0;
         switch (keyCode) {

--- a/client/src/main/java/org/kunp/map/MapPanel.java
+++ b/client/src/main/java/org/kunp/map/MapPanel.java
@@ -117,7 +117,8 @@ public class MapPanel extends JPanel {
             while(iter.hasNext()){
                 Location loc = (Location) iter.next();
                 if(loc.getRoomNumber() == mapY * 3 + mapX + 1){
-                    g.drawImage(Constants.taggerImage, loc.getX(), loc.getY(), Constants.PLAYER_SIZE_X, Constants.PLAYER_SIZE_Y, null);
+                    if(loc.getRole() == 0) g.drawImage(Constants.taggerImage, loc.getX(), loc.getY(), Constants.PLAYER_SIZE_X, Constants.PLAYER_SIZE_Y, null);
+                    else g.drawImage(Constants.runawayImage, loc.getX(), loc.getY(), Constants.PLAYER_SIZE_X, Constants.PLAYER_SIZE_Y, null);
                 }
             }
         }


### PR DESCRIPTION
## 🐣Title
[Fix/client/map] 게임 중 나간 플레이어 맵에 표시X, 역할에 따른 플레이어 그래픽 그리기
---

<br/>

## 🐣Part
Client
---

<br/>

## 🐣Key Changes
1. 서버에서 보내는 214 타입의 메시지를 받아, 나간 유저를 더 이상 맵에 그리지 않게 수정했습니다.
2. 210 타입에 추가된 role 인자(마지막 인자)에 따라 술래/도망자의 그래픽을 그리도록 수정했습니다.
---

<br/>

## 🐣Simulation

---

<br/>

## 🐣To Reviewer

---

<br/>

## 🐣Next

---

 <br/>

## 🐣Issue
1. "[Fix/client/fix-request] 클라이언트 request 메세지 마지막 인자 삭제"에 따라, 클라이언트가 보내는 메시지의 마지막 인자가 삭제된 상황입니다. 그런데 현재 클라이언트가 201 리퀘스트(move)를 보냈을때, 마지막인자에 1을 추가하지 않으면 서버에서 메시지를 파싱하는 과정에서 OutOfIndex exception이 발생합니다. 제가 테스트할 때는 마지막 인자를 추가해서 보내니 잘 동작했고, 지금은 마지막 인자를 다시 뺐습니다. 
---


<br/>