### PR TITLE
[Fix/client/map] 게임 중 나간 플레이어 맵에 표시X, 역할에 따른 플레이어 그래픽 그리기 

### DIFF
--- a/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
+++ b/client/src/main/java/org/kunp/inner/InnerWaitingRoomComponent.java
@@ -63,11 +63,12 @@ public class InnerWaitingRoomComponent extends JPanel {
             case "113" -> SwingUtilities.invokeLater(() -> {
                 System.out.println("Game starting...");
                 try {
-                    String role = tokens[1].equals("0") ? "tagger" : "normal";
+                    int gameId = Integer.parseInt(tokens[1]);
+                    String role = tokens[2].equals("0") ? "tagger" : "normal";
                     Player player = new Player(stateManager, serverCommunicator, screenManager,
-                            Integer.parseInt(tokens[2]), Integer.parseInt(tokens[3]), role, out, stateManager.getSessionId()
+                            Integer.parseInt(tokens[3]), Integer.parseInt(tokens[4]), role, out, stateManager.getSessionId(), gameId
                     );
-                    screenManager.addScreen("Map", new Map(stateManager, serverCommunicator, screenManager, player, stateManager.getSessionId(), in, out));
+                    screenManager.addScreen("Map", new Map(stateManager, serverCommunicator, screenManager, player, stateManager.getSessionId(), in, out, gameId));
                     System.out.println("Map screen added successfully.");
                     stateManager.switchTo("Map");
                 } catch (Exception ex) {

--- a/client/src/main/java/org/kunp/map/Location.java
+++ b/client/src/main/java/org/kunp/map/Location.java
@@ -1,19 +1,22 @@
 package org.kunp.map;
 
 public class Location{
-    int roomNumber, x, y;
-    public Location(int roomNumber, int x, int y){
+    int roomNumber, x, y, role;
+    public Location(int role, int roomNumber, int x, int y){
+        this.role = role;
         this.roomNumber = roomNumber;
         this.x = x;
         this.y = y;
     }
 
-    public void setLocation(int roomNumber, int x, int y){
+    public void setLocation(int role, int roomNumber, int x, int y){
+        this.role = role;
         this.roomNumber = roomNumber;
         this.x = x;
         this.y = y;
     }
 
+    public int getRole() { return role; }
     public int getRoomNumber(){
         return roomNumber;
     }

--- a/client/src/main/java/org/kunp/map/Map.java
+++ b/client/src/main/java/org/kunp/map/Map.java
@@ -19,10 +19,12 @@ public class Map extends JPanel {
     private final Timer moveTimer;
     private final String sessionId;
     private final HashMap<String, Location> locations = new HashMap<>();
+    private final int gameId;
 
-    public Map(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, Player player, String sessionId, BufferedReader in, PrintWriter out) {
+    public Map(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, Player player, String sessionId, BufferedReader in, PrintWriter out, int gameId) {
         this.player = player;
         this.sessionId = sessionId;
+        this.gameId = gameId;
 
         setPreferredSize(new Dimension(Constants.MAP_SIZE, Constants.MAP_SIZE));
         setFocusable(true);
@@ -58,7 +60,6 @@ public class Map extends JPanel {
             String[] tokens = message.split("\\|");
             String type = tokens[0];
             if(type.equals("210") || type.equals("211") || type.equals("212")){
-                System.out.println(message);
                 String mover_sessionId = tokens[1];
                 int x = Integer.parseInt(tokens[2]), y = Integer.parseInt(tokens[3]);
                 int mapIdx = Integer.parseInt(tokens[4]);
@@ -69,9 +70,9 @@ public class Map extends JPanel {
                 }
                 repaint();
             }else if(type.equals("213")){
-                String gameId = tokens[1];
+                String overed_gameId = tokens[1];
                 String result = Integer.parseInt(tokens[2]) == 1 ? "도망자 승리" : "술래 승리";
-                screenManager.addScreen("Result", new ResultComponent(stateManager, serverCommunicator, screenManager,result, gameId, in, out));
+                screenManager.addScreen("Result", new ResultComponent(stateManager, serverCommunicator, screenManager,result, overed_gameId, in, out));
                 SwingUtilities.invokeLater(() -> {
                     stateManager.switchTo("Result");
                 });

--- a/client/src/main/java/org/kunp/map/Map.java
+++ b/client/src/main/java/org/kunp/map/Map.java
@@ -58,12 +58,14 @@ public class Map extends JPanel {
             String[] tokens = message.split("\\|");
             String type = tokens[0];
             if(type.equals("210") || type.equals("211") || type.equals("212")){
+                System.out.println(message);
                 String mover_sessionId = tokens[1];
                 int x = Integer.parseInt(tokens[2]), y = Integer.parseInt(tokens[3]);
                 int mapIdx = Integer.parseInt(tokens[4]);
+                int role = Integer.parseInt(tokens[6]);
                 synchronized (locations){
-                    if(!locations.containsKey(mover_sessionId)) locations.put(mover_sessionId, new Location(mapIdx, x, y));
-                    else locations.get(mover_sessionId).setLocation(mapIdx, x, y);
+                    if(!locations.containsKey(mover_sessionId)) locations.put(mover_sessionId, new Location(role, mapIdx, x, y));
+                    else locations.get(mover_sessionId).setLocation(role, mapIdx, x, y);
                 }
                 repaint();
             }else if(type.equals("213")){
@@ -73,6 +75,11 @@ public class Map extends JPanel {
                 SwingUtilities.invokeLater(() -> {
                     stateManager.switchTo("Result");
                 });
+            }else if(type.equals("214")){
+                String disconnectedSessionId = tokens[1];
+                synchronized (locations){
+                    locations.remove(disconnectedSessionId);
+                }
             }
         });
 
@@ -117,7 +124,6 @@ public class Map extends JPanel {
     }
 
     private void movePlayer(int keyCode) {
-        System.out.println("key identified");
         int newX = player.getX(), newY = player.getY();
         int xx = 0, yy = 0;
         switch (keyCode) {

--- a/client/src/main/java/org/kunp/map/MapPanel.java
+++ b/client/src/main/java/org/kunp/map/MapPanel.java
@@ -117,7 +117,8 @@ public class MapPanel extends JPanel {
             while(iter.hasNext()){
                 Location loc = (Location) iter.next();
                 if(loc.getRoomNumber() == mapY * 3 + mapX + 1){
-                    g.drawImage(Constants.taggerImage, loc.getX(), loc.getY(), Constants.PLAYER_SIZE_X, Constants.PLAYER_SIZE_Y, null);
+                    if(loc.getRole() == 0) g.drawImage(Constants.taggerImage, loc.getX(), loc.getY(), Constants.PLAYER_SIZE_X, Constants.PLAYER_SIZE_Y, null);
+                    else g.drawImage(Constants.runawayImage, loc.getX(), loc.getY(), Constants.PLAYER_SIZE_X, Constants.PLAYER_SIZE_Y, null);
                 }
             }
         }

--- a/client/src/main/java/org/kunp/map/Player.java
+++ b/client/src/main/java/org/kunp/map/Player.java
@@ -13,8 +13,9 @@ public class Player {
     private int mapIdx;
     private PrintWriter out;
     private ServerCommunicator serverCommunicator;
+    private int gameId;
 
-    public Player(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, int startX, int startY, String role, PrintWriter out, String sessionId) {
+    public Player(StateManager stateManager, ServerCommunicator serverCommunicator, ScreenManager screenManager, int startX, int startY, String role, PrintWriter out, String sessionId, int gameId) {
         this.x = startX;
         this.y = startY;
         this.role = role;
@@ -22,6 +23,7 @@ public class Player {
         this.sessionId = sessionId;
         this.mapIdx = 5;
         this.serverCommunicator = serverCommunicator;
+        this.gameId = gameId;
     }
 
     public int getX() {
@@ -50,12 +52,12 @@ public class Player {
     }
 
     public void sendInteraction(){
-        String requestMessage = String.format("202|%s|%s|%d|%d", sessionId, x, y, mapIdx);
+        String requestMessage = String.format("202|%s|%s|%d|%d|%d", sessionId, x, y, mapIdx, gameId);
         serverCommunicator.sendRequest(requestMessage);
     }
 
     private void sendLocation() {
-        String requestMessage = String.format("201|%s|%s|%d|%d", sessionId, x, y, mapIdx);
+        String requestMessage = String.format("201|%s|%s|%d|%d|%d", sessionId, x, y, mapIdx, gameId);
         serverCommunicator.sendRequest(requestMessage);
     }
 }


### PR DESCRIPTION
## 🐣Title
[Fix/client/map] 게임 중 나간 플레이어 맵에 표시X, 역할에 따른 플레이어 그래픽 그리기 
---

<br/>

## 🐣Part
Client
---

<br/>

## 🐣Key Changes
1. 서버에서 보내는 214 타입의 메시지를 받아, 나간 유저를 더 이상 맵에 그리지 않게 수정했습니다.
2. 210 타입에 추가된 role 인자(마지막 인자)에 따라 술래/도망자의 그래픽을 그리도록 수정했습니다.
3. 서버가 보내는 113 타입의 메시지를 받아, gameId를 210번 (move) 및 211번 (상호작용) 리퀘스트에 붙여보냅니다.
---

<br/>

## 🐣Simulation

https://github.com/user-attachments/assets/c68fe73b-5303-4b29-98b7-54e3c572e356



---

<br/>

## 🐣To Reviewer

---

<br/>

## 🐣Next

---

 <br/>

## 🐣Issue

---


<br/>